### PR TITLE
rewrite build script

### DIFF
--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -42,7 +42,7 @@ palette = {
 with_errors = False
 
 ####################
-# functions and classes
+# functions, classes
 ####################
 
 def log(message, color="white"):
@@ -135,7 +135,7 @@ for input_index, input_paper in enumerate(input_papers):
     log(f"Paper {input_index + 1} of {len(input_papers)}")
     log(f"Line number {input_paper.get('__line_number__')}")
 
-    # catch errors
+    # catch errors in processing paper
     try:
 
         # check that paper entry is dictionary/object

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -12,9 +12,11 @@ from yaml.loader import SafeLoader
 ####################
 
 # input and output files
+input_file = "research-input.yml"
+output_file = "research-output.yml"
 current_dir = os.path.dirname(os.path.realpath(__file__))
-input_file = os.path.join(current_dir, "research-input.yml")
-output_file = os.path.join(current_dir, "research-output.yml")
+input_path = os.path.join(current_dir, input_file)
+output_path = os.path.join(current_dir, output_file)
 
 # input papers
 input_papers = []
@@ -95,27 +97,27 @@ def clean_date(date):
 os.system("")
 
 # check that input file exists
-if not os.path.isfile(input_file):
-    exit("Can't find research-input.yml")
+if not os.path.isfile(input_path):
+    exit(f"Can't find {input_file}")
 
 # try to open input file
 try:
-    with open(input_file, encoding="utf8") as file:
+    with open(input_path, encoding="utf8") as file:
         # try to parse input file as yaml
         try:
             input_papers = yaml.load(file, Loader=SafeLineLoader)
         except Exception:
-            exit("Can't parse research-input.yml. Make sure it's valid YAML.")
+            exit(f"Can't parse {input_file}. Make sure it's valid YAML.")
 except Exception:
-    exit("Can't open research-input.yml")
+    exit(f"Can't open {input_file}")
 
 # check that top level of input yaml is list/array
 if type(input_papers) != list:
-    exit("research-input.yml not in expected format")
+    exit(f"{input_file} not in expected format")
 
 # try to open existing output file and parse as yaml
 try:
-    with open(output_file, encoding="utf8") as file:
+    with open(output_path, encoding="utf8") as file:
         output_papers = yaml.load(file, Loader=SafeLineLoader)
         if type(output_papers) != list:
             raise Exception()
@@ -240,10 +242,10 @@ for new_index, new_paper in enumerate(new_papers):
 
 # write new list of papers to output file
 try:
-    with open(output_file, mode="w") as file:
+    with open(output_path, mode="w") as file:
         yaml.dump(new_papers, file, default_flow_style=False, sort_keys=False)
 except Exception:
-    exit("Can't save research-output.yml")
+    exit(f"Can't save {output_file}")
 
 if with_errors:
     log("Done, with errors", "yellow")

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -120,7 +120,6 @@ try:
         if type(output_papers) != list:
             raise Exception()
 except Exception:
-    log("Problem with existing research-output.yml", "yellow")
     output_papers = []
 
 ####################

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -42,7 +42,7 @@ palette = {
 with_errors = False
 
 ####################
-# functions
+# functions and classes
 ####################
 
 def log(message, color="white"):

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -160,7 +160,7 @@ for input_index, input_paper in enumerate(input_papers):
         # find same paper in existing output
         existing_paper = None
         for output_paper in output_papers:
-            if output_paper.get("id") == input_id:
+            if type(output_paper) == dict and output_paper.get("id") == input_id:
                 existing_paper = output_paper
                 break
 

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -25,7 +25,7 @@ input_file = os.path.join(current_dir, "research-input.yml")
 output_file = os.path.join(current_dir, "research-output.yml")
 
 # log wih color
-def log(message, color="white", exit=False):
+def log(message, color="white"):
     palette = {
         "white": "\033[97m",
         "red": "\033[91m",
@@ -54,7 +54,7 @@ try:
         except Exception:
             exit("Can't parse research-input.yml. Make sure it's valid YAML.")
 except Exception:
-    exit("Can't open research-input.yml", True)
+    exit("Can't open research-input.yml")
 
 # check that top level of input yaml is list/array
 if type(input_papers) != list:

--- a/_data/build-research.py
+++ b/_data/build-research.py
@@ -25,9 +25,6 @@ output_papers = []
 # new output papers
 new_papers = []
 
-# error flag
-with_errors = False
-
 # default paper date, year month day
 default_date = [1900, 1, 1]
 
@@ -40,6 +37,9 @@ palette = {
     "yellow": "\033[93m",
     "reset": "\033[0m"
 }
+
+# flag for "done with errors"
+with_errors = False
 
 ####################
 # functions

--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -1,34 +1,8 @@
 - id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
-  date: 2020-6-2
   extra-links:
     - type: manubot
       link: https://greenelab.github.io/knowledge-graph-review/
   tags:
     - knowledge graphs
-
-- id: doi:10.1371/journal.pcbi.1007128
-  image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
-  repo: greenelab/meta-review
-  extra-links:
-    - type: manubot
-      link: https://greenelab.github.io/meta-review/
-    - type: source
-      link: https://github.com/greenelab/meta-review
-    - type: website
-      link: http://manubot.org/
-
-
-- id: doi:10.7554/eLife.32822
-  image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
-  extra-links:
-    - type: preprint
-      link: https://doi.org/10.7287/peerj.preprints.3100v1
-    - type: manubot
-      link: https://greenelab.github.io/scihub-manuscript/
-    - type: source
-      link: https://github.com/greenelab/scihub-manuscript
-      text: Manuscript source
-    - type: source
-      link: https://github.com/greenelab/scihub
-      text: Analyses source
+  sup: bruh

--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -1,8 +1,33 @@
 - id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
+  date: 2020-6-2
   extra-links:
     - type: manubot
       link: https://greenelab.github.io/knowledge-graph-review/
   tags:
     - knowledge graphs
-  sup: bruh
+
+- id: doi:10.1371/journal.pcbi.1007128
+  image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
+  repo: greenelab/meta-review
+  extra-links:
+    - type: manubot
+      link: https://greenelab.github.io/meta-review/
+    - type: source
+      link: https://github.com/greenelab/meta-review
+    - type: website
+      link: http://manubot.org/
+
+- id: doi:10.7554/eLife.32822
+  image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
+  extra-links:
+    - type: preprint
+      link: https://doi.org/10.7287/peerj.preprints.3100v1
+    - type: manubot
+      link: https://greenelab.github.io/scihub-manuscript/
+    - type: source
+      link: https://github.com/greenelab/scihub-manuscript
+      text: Manuscript source
+    - type: source
+      link: https://github.com/greenelab/scihub
+      text: Analyses source

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -3,7 +3,7 @@
   - David N. Nicholson
   - Casey S. Greene
   publisher: Computational and Structural Biotechnology Journal
-  date: '2020-06-02'
+  date: '2020-01-01'
   link: https://doi.org/gg7m48
   id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
@@ -12,50 +12,4 @@
     link: https://greenelab.github.io/knowledge-graph-review/
   tags:
   - knowledge graphs
-- title: Open collaborative writing with Manubot
-  authors:
-  - Daniel S. Himmelstein
-  - Vincent Rubinetti
-  - David R. Slochower
-  - Dongbo Hu
-  - Venkat S. Malladi
-  - Casey S. Greene
-  - Anthony Gitter
-  publisher: PLOS Computational Biology
-  date: '2019-06-24'
-  link: https://doi.org/c7np
-  id: doi:10.1371/journal.pcbi.1007128
-  image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
-  repo: greenelab/meta-review
-  extra-links:
-  - type: manubot
-    link: https://greenelab.github.io/meta-review/
-  - type: source
-    link: https://github.com/greenelab/meta-review
-  - type: website
-    link: http://manubot.org/
-- title: Sci-Hub provides access to nearly all scholarly literature
-  authors:
-  - Daniel S Himmelstein
-  - Ariel Rodriguez Romero
-  - Jacob G Levernier
-  - Thomas Anthony Munro
-  - Stephen Reid McLaughlin
-  - Bastian Greshake Tzovaras
-  - Casey S Greene
-  publisher: eLife
-  date: '2018-03-01'
-  link: https://doi.org/ckcj
-  id: doi:10.7554/eLife.32822
-  image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
-  extra-links:
-  - type: preprint
-    link: https://doi.org/10.7287/peerj.preprints.3100v1
-  - type: manubot
-    link: https://greenelab.github.io/scihub-manuscript/
-  - type: source
-    link: https://github.com/greenelab/scihub-manuscript
-    text: Manuscript source
-  - type: source
-    link: https://github.com/greenelab/scihub
-    text: Analyses source
+  sup: bruh

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -3,7 +3,7 @@
   - David N. Nicholson
   - Casey S. Greene
   publisher: Computational and Structural Biotechnology Journal
-  date: '2020-01-01'
+  date: '2020-06-02'
   link: https://doi.org/gg7m48
   id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
@@ -12,4 +12,50 @@
     link: https://greenelab.github.io/knowledge-graph-review/
   tags:
   - knowledge graphs
-  sup: bruh
+- title: Open collaborative writing with Manubot
+  authors:
+  - Daniel S. Himmelstein
+  - Vincent Rubinetti
+  - David R. Slochower
+  - Dongbo Hu
+  - Venkat S. Malladi
+  - Casey S. Greene
+  - Anthony Gitter
+  publisher: PLOS Computational Biology
+  date: '2019-06-24'
+  link: https://doi.org/c7np
+  id: doi:10.1371/journal.pcbi.1007128
+  image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
+  repo: greenelab/meta-review
+  extra-links:
+  - type: manubot
+    link: https://greenelab.github.io/meta-review/
+  - type: source
+    link: https://github.com/greenelab/meta-review
+  - type: website
+    link: http://manubot.org/
+- title: Sci-Hub provides access to nearly all scholarly literature
+  authors:
+  - Daniel S Himmelstein
+  - Ariel Rodriguez Romero
+  - Jacob G Levernier
+  - Thomas Anthony Munro
+  - Stephen Reid McLaughlin
+  - Bastian Greshake Tzovaras
+  - Casey S Greene
+  publisher: eLife
+  date: '2018-03-01'
+  link: https://doi.org/ckcj
+  id: doi:10.7554/eLife.32822
+  image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
+  extra-links:
+  - type: preprint
+    link: https://doi.org/10.7287/peerj.preprints.3100v1
+  - type: manubot
+    link: https://greenelab.github.io/scihub-manuscript/
+  - type: source
+    link: https://github.com/greenelab/scihub-manuscript
+    text: Manuscript source
+  - type: source
+    link: https://github.com/greenelab/scihub
+    text: Analyses source

--- a/_includes/card-search.html
+++ b/_includes/card-search.html
@@ -1,6 +1,6 @@
 <div class="card_search">
   <div class="card_search_box">
-    <input class="card_search_input" />
+    <input class="card_search_input" disabled/>
     <i class="fas fa-search"></i>
   </div>
   <div class="card_search_info">

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -16,6 +16,7 @@
     <img
       src="{{ include.image | relative_url }}"
       onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
+      loading="lazy"
     >
   </a>
   <div class="card_text">
@@ -54,7 +55,7 @@
       {% endif %}
     >
     {%- endif -%}
-      {{- row | markdownify | remove: "<p>" | remove: "</p>" -}}
+      {{- row -}}
     {%- if firstchar != "<" -%}
     </p>
     {%- endif -%}

--- a/_includes/feature.html
+++ b/_includes/feature.html
@@ -3,7 +3,7 @@
     {% if include.link %}href="{{ include.link | relative_url }}"{% endif %}
     class="feature_image"
   >
-    <img src="{{ include.image | relative_url }}" />
+    <img src="{{ include.image | relative_url }}" loading="lazy" />
   </a>
   <div class="feature_text">
     {%- if include.heading -%}

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -16,6 +16,7 @@
         max-height: {{ include.height }};
         {% endif %}
       "
+      loading="lazy"
     />
   </a>
   {%- if include.caption -%}

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -29,7 +29,7 @@
     class="gallery_item"
     data-tooltip="{{ tooltip }}"
   >
-    <img src="{{ image | relative_url }}">
+    <img src="{{ image | relative_url }}" loading="lazy">
   </a>
   {%- endif -%}
 

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -6,6 +6,7 @@
     <img
       src="{{ include.image | relative_url }}"
       onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
+      loading="lazy"
     >
   </span>
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ title: Home
 [Lab Website Template](https://github.com/greenelab/lab-website-template) is an easy-to-use, flexible website template for [labs](https://www.greenelab.com/), with automatic citations, GitHub tag imports, pre-built components, and more.
 Spend less time reinventing the wheel, and more time running your lab.
 
-{% include big-link.html icon="fab fa-github" text="See the template and readme on GitHub" link="https://github.com/greenelab/lab-website-template" %}{:.center}
+{% include big-link.html icon="fab fa-github" text="See the template on GitHub" link="https://github.com/greenelab/lab-website-template" %}{% include big-link.html icon="fas fa-book" text="See the documentation" link="https://github.com/greenelab/lab-website-template/wiki" %}{:.center}
 
 <!-- section break -->
 

--- a/js/card-search.js
+++ b/js/card-search.js
@@ -20,6 +20,9 @@ const createSearch = () => {
   // attach filter function to search box input
   searchInput.addEventListener("input", debounce(filterCards, 50));
 
+  // enable search input to indicate that script has finished loading
+  searchInput.removeAttribute("disabled");
+
   // get url param and search
   loadUrlSearch();
   filterCards();


### PR DESCRIPTION
Closes #22 
Closes #24 

Makes build script much more robust, to prevent this from happening in the future: #19 

- add more comments (but remove comments at top of file that are already covered in the wiki documentation)
- refactor code to < 80 char wide
- load yaml with line numbers
- add log and exit funcs with color for easier visual identification
- add check for input file
- add specific catch/errors for opening and parsing input yaml
- add check that top level of input yaml is array
- add error flag
- add single default date
- log input yaml line number along with "paper X of N" for much easier troubleshooting
- log doi/id
- add check that paper is object
- add check that paper has id field
- add check that paper is not a duplicate
- add check that existing output papers are lists of dicts
- add catch/error to manubot command
- make field extraction from manubot citation more robust
- add catch/error for formatting dates
- add check for writing output file
- add "done" or "done with errors"
- removes markdown support in card components (and resource list component) to fix #24
- add lazy-loading to images so research page with 100s of papers doesn't take forever to load
- disables card search box until associated javascript has finished loading