### PR TITLE
Rewrite automatic citations script

### DIFF
--- a/.github/workflows/generate-citations.yaml
+++ b/.github/workflows/generate-citations.yaml
@@ -30,3 +30,4 @@ jobs:
         with:
           file_pattern: "_data/research-output.yaml"
           commit_message: "Generate citations"
+          push_options: --force

--- a/_config.yaml
+++ b/_config.yaml
@@ -25,7 +25,6 @@ github: your-lab
 twitter: YourLabHandle
 instagram: YourLabHandle
 youtube: YourLabChannel
-rss: feed.xml
 
 # base directory where site is hosted
 baseurl: /lab-website-template

--- a/_data/generate-citations.py
+++ b/_data/generate-citations.py
@@ -24,9 +24,6 @@ default_date = [1900, 1, 1]
 # util
 ####################
 
-# allow printing ANSI color codes
-os.system("")
-
 # colored logging
 def error(message): print(f"\033[91m{message}\033[0m"); sys.exit(1) # red
 def warning(message): print(f"\033[93m{message}\033[0m") # yellow

--- a/_data/generate-citations.py
+++ b/_data/generate-citations.py
@@ -197,7 +197,7 @@ for index, paper in enumerate(papers):
 
         if cached:
             # use existing citation to save time
-            info("Already in output. Using existing citation.")
+            info("Using existing citation")
             new_citations.append(cached)
 
         else:
@@ -258,9 +258,9 @@ for index, paper in enumerate(papers):
 
 section()
 
-# go through new output papers
+# go through new citations
 for citation in new_citations:
-    # merge properties from input paper into new output paper
+    # merge in properties from input paper
     citation.update(find_match(citation, papers))
 
     # delete line number field

--- a/_data/research-output.yaml
+++ b/_data/research-output.yaml
@@ -1,20 +1,21 @@
-# GENERATED AUTOMATICALLY FROM RESEARCH.YAML, DO NOT EDIT
+# GENERATED AUTOMATICALLY, DO NOT EDIT
 
-- title: Constructing knowledge graphs and their biomedical applications
+- id: doi:10.1016/j.csbj.2020.05.017
+  title: Constructing knowledge graphs and their biomedical applications
   authors:
   - David N. Nicholson
   - Casey S. Greene
   publisher: Computational and Structural Biotechnology Journal
   date: '2020-06-02'
   link: https://doi.org/gg7m48
-  id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
   extra-links:
   - type: manubot
     link: https://greenelab.github.io/knowledge-graph-review/
   tags:
   - knowledge graphs
-- title: Open collaborative writing with Manubot
+- id: doi:10.1371/journal.pcbi.1007128
+  title: Open collaborative writing with Manubot
   authors:
   - Daniel S. Himmelstein
   - Vincent Rubinetti
@@ -26,7 +27,6 @@
   publisher: PLOS Computational Biology
   date: '2019-06-24'
   link: https://doi.org/c7np
-  id: doi:10.1371/journal.pcbi.1007128
   image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
   repo: greenelab/meta-review
   extra-links:
@@ -36,7 +36,8 @@
     link: https://github.com/greenelab/meta-review
   - type: website
     link: http://manubot.org/
-- title: Sci-Hub provides access to nearly all scholarly literature
+- id: doi:10.7554/eLife.32822
+  title: Sci-Hub provides access to nearly all scholarly literature
   authors:
   - Daniel S Himmelstein
   - Ariel Rodriguez Romero
@@ -48,7 +49,6 @@
   publisher: eLife
   date: '2018-03-01'
   link: https://doi.org/ckcj
-  id: doi:10.7554/eLife.32822
   image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
   extra-links:
   - type: preprint

--- a/_data/research.yaml
+++ b/_data/research.yaml
@@ -1,4 +1,4 @@
-- id: doi:10.1016/j.csbj.2020.05.017
+4 - 4 id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
   date: 2020-6-2
   extra-links:

--- a/_data/research.yaml
+++ b/_data/research.yaml
@@ -1,4 +1,4 @@
-4 - 4 id: doi:10.1016/j.csbj.2020.05.017
+- id: doi:10.1016/j.csbj.2020.05.017
   image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
   date: 2020-6-2
   extra-links:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,6 @@
     {% include social-link.html type="instagram" link=site.instagram large=true %}
     {% include social-link.html type="youtube" link=site.youtube large=true %}
     {% include social-link.html type="linkedin" link=site.linkedin large=true %}
-    {% include social-link.html type="rss" link=site.rss large=true %}
   </div>
   <!-- <div class="footer_row">
     &copy; <script>document.write(new Date().getFullYear())</script> {{ site.title }}

--- a/_includes/social-link.html
+++ b/_includes/social-link.html
@@ -46,12 +46,6 @@
 {%- assign link = include.link | default: "" | prepend: "https://www.linkedin.com/in/" -%}
 {%- endif -%}
 
-{%- if include.type == "rss" -%}
-{%- assign icon = "fas fa-rss" -%}
-{%- assign tooltip = "RSS Feed" -%}
-{%- assign link = include.link | absolute_url -%}
-{%- endif -%}
-
 {%- comment -%}
 To add more options for icons, see:
 https://fontawesome.com/icons?d=gallery&q=icon&m=free


### PR DESCRIPTION
- rewrite automatic citations script in response to https://github.com/greenelab/greenelab.com/pull/35
    - rename variables for clarity
    - in general, simplify and refactor
    - remove some util functions
    - make yaml structure and missing id fields critical errors
    - make manubot fail as critical error
    - match output to input by id rather than index
    - write warning to top of output file
- add force push option to hopefully fix and close #30
- remove RSS as social media icon. leave just the meta tag tag can be detected by browser extensions. if some RSS users complain that they need a clickable link to the RSS feed file to subscribe (maybe their RSS client/extension can't detect the meta tag?), we can always add it in again easily