### PR TITLE
Fix GitHub Tooltip

### DIFF
--- a/_data/links.yaml
+++ b/_data/links.yaml
@@ -59,7 +59,7 @@ google-scholar:
 github:
   icon: fab fa-github
   text: GitHub
-  tooltip: Google Scholar
+  tooltip: GitHub
   link: https://github.com/$LINK
 
 twitter:


### PR DESCRIPTION
"google scholar" -> "GitHub"