### PR TITLE
move auto-cite config to main config, fix tooltip

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -17,6 +17,14 @@ links:
   instagram: YourLabHandle
   youtube: YourLabChannel
 
+# automatic citations
+auto-cite:
+  plugins:
+    - name: sources
+      input:
+        - ../_data/sources.yaml
+  output: ../_data/citations.yaml
+
 ### advanced settings
 
 # default front matter parameters for markdown files

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -1,6 +1,7 @@
 {%- assign emptyarray = "" | split: "," -%}
 {%- assign id = include.id | default: "" -%}
-{%- assign citations = site.data.citations | default: emptyarray -%} 
+{%- assign output = site.auto-cite.output | default: "citations" | split: "/" | last | split: "." | pop | join: "" -%}
+{%- assign citations = site.data[output] | default: emptyarray -%} 
 
 {%- assign citation = nil -%}
 {%- for c in citations -%}

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -1,10 +1,12 @@
 from util import *
-import importlib
+from importlib import import_module
 
 # config info for input/output files and plugins
 config = {}
 try:
-    config = load_data("./config.yaml", type_check=False)
+    config = load_data("../_config.yaml", type_check=False).get("auto-cite")
+    if not config:
+        raise Exception("Couldn't find auto-cite config")
 except Exception as message:
     log(message, 3, "red")
     exit(1)
@@ -36,7 +38,7 @@ for plugin in config.get("plugins", []):
             log(message, 3, "red")
             exit(1)
 
-        plugin_sources = importlib.import_module(f"plugins.{name}").main(data)
+        plugin_sources = import_module(f"plugins.{name}").main(data)
 
         log(f"Got {len(plugin_sources)} sources", 2, "green")
 

--- a/auto-cite/config.yaml
+++ b/auto-cite/config.yaml
@@ -1,6 +1,0 @@
-plugins:
-  - name: sources
-    input:
-      - ../_data/sources.yaml
-
-output: ../_data/citations.yaml

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -40,6 +40,7 @@ const createTooltips = () => {
   const open = ({ target }) => {
     if (popper) popper.destroy();
     popper = Popper.createPopper(target, tooltip, options(target.dataset));
+    tooltip.style.display = "";
     tooltip.dataset.show = true;
     tooltip.querySelector(".tooltip_content").innerHTML =
       target.dataset.tooltip;
@@ -49,6 +50,11 @@ const createTooltips = () => {
   const close = () => {
     window.clearTimeout(timer);
     tooltip.dataset.show = false;
+    tooltip.addEventListener(
+      "transitionend",
+      () => (tooltip.style.display = "none"),
+      { once: true }
+    );
   };
 
   // loop through elements with data-tooltip attribute


### PR DESCRIPTION
Closes #77 
Closes #75

- set tooltip display to none after it fades out to avoid potential layout issues
- move auto-cite configuration from its own separate config file to the main site config, to be less confusing
- make citations component get the location of the auto-cite output citations from the config file, rather than being hard-coded to "citations.yaml"