### PR TITLE
Accessibility, bug, performance, and misc fixes

### DIFF
--- a/404.md
+++ b/404.md
@@ -8,15 +8,4 @@ permalink: /404.html
 Try searching the whole site for the content you want:
 {:.center}
 
-<input type="text" oninput="onInput(this)" placeholder="Search site">
-{% include link.html type="search" link="" icon="" style="button" %}
-{:.center}
-
-<script>
-  const onInput = (target) => {
-    const google = "https://www.google.com/search?q=site:";
-    const site = "{{ '' | absolute_url }}";
-    const query = target.value;
-    target.nextElementSibling.href = google + site + " " + query;
-  };
-</script>
+{% include site-search.html %}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,13 @@
+# GitHub citation metadata for lab-website-template itself
+
 cff-version: 1.2.0
 authors:
-- family-names: "Rubinetti"
-  given-names: "Vincent"
-  orcid: "https://orcid.org/0000-0002-4655-3773"
-- family-names: "Greene"
-  given-names: "Casey"
-  orcid: "https://orcid.org/0000-0001-8713-9213"
+  - family-names: "Rubinetti"
+    given-names: "Vincent"
+    orcid: "https://orcid.org/0000-0002-4655-3773"
+  - family-names: "Greene"
+    given-names: "Casey"
+    orcid: "https://orcid.org/0000-0001-8713-9213"
 title: "Lab Website Template"
 version: 0.4.1
 date-released: 2021-08-23

--- a/README.md
+++ b/README.md
@@ -15,24 +15,60 @@ How's our documentation?
 ## Gallery
 
 <kbd>
-  <a href="https://user-images.githubusercontent.com/8326331/112500343-acc58480-8d5e-11eb-9795-9592625872fc.png">
-    <img src="https://user-images.githubusercontent.com/8326331/112500343-acc58480-8d5e-11eb-9795-9592625872fc.png" height="150px" alt="Screenshot" />
+  <a href="https://greenelab.github.io/lab-website-template/">
+    <img src="https://user-images.githubusercontent.com/8326331/140773232-0c0f0780-a6ae-4fea-838b-b68f117d8ba0.png" height="150px" />
+    <br>
+    Lab Website Template
   </a>
 </kbd>
 
 <kbd>
-  <a href="https://greenelab.github.io/lab-website-template/">
-    <img src="https://raw.githubusercontent.com/greenelab/lab-website-template/main/favicons/share-thumbnail.jpg?raw=true" height="150px" alt="Lab Website Template" />
+  <a href="https://tislab.org/">
+    <img src="https://user-images.githubusercontent.com/8326331/140774758-58d13120-c091-41ea-87e3-d2219a90f1d9.png" height="150px" />
+    <br>
+    Translational and Integrative Sciences Lab
   </a>
 </kbd>
 
 <kbd>
   <a href="https://greenelab.com/">
-    <img src="https://greenelab.com/favicons/share-thumbnail.jpg" height="150px" alt="GreeneLab.com" />
+    <img src="https://user-images.githubusercontent.com/8326331/140775456-aa6afad1-ba72-48f6-803e-279f8c1011e9.png" height="150px" />
+    <br>
+    Greene Lab
   </a>
 </kbd>
 
-more coming soon...
+<kbd>
+  <a href="https://www.waysciencelab.com/">
+    <img src="https://user-images.githubusercontent.com/8326331/140776192-80a802d5-be4f-4aeb-b159-f473bbb10fbe.png" height="150px" />
+    <br>
+    Way Lab
+  </a>
+</kbd>
+
+<kbd>
+  <a href="https://fong-lab.github.io/">
+    <img src="https://user-images.githubusercontent.com/8326331/140777326-e1da4b0f-053b-4355-823d-077fc1078a5b.png" height="150px" />
+    <br>
+    Fong Lab
+  </a>
+</kbd>
+
+<kbd>
+  <a href="https://mmv-lab.github.io/">
+    <img src="https://user-images.githubusercontent.com/8326331/140778499-787f6d7f-f07f-43ee-9942-5ac8f955443a.png" height="150px" />
+    <br>
+    Microscopy Machine Vision Lab
+  </a>
+</kbd>
+
+<kbd>
+  <a href="https://quantmarineecolab.github.io/">
+    <img src="https://user-images.githubusercontent.com/8326331/140778904-42abe18d-bcbe-4861-8993-911c95e6b6f6.png" height="150px" />
+    <br>
+    Quantitative Marine Ecology Lab
+  </a>
+</kbd>
 
 ## Features
 
@@ -46,7 +82,7 @@ more coming soon...
   - image galleries
   - multi-size cards with image and text
   - citations
-  - ...[and more](https://github.com/greenelab/lab-website-template/wiki/Components)!
+  - ...[and many more](https://github.com/greenelab/lab-website-template/wiki/Components)!
 - A **home page**, where you can highlight the most important things that make your lab special
 - A **research page**, with a sorted, searchable list of all your published works
 - A **tools page**, where you can show off your software, datasets, or other useful things

--- a/README.md
+++ b/README.md
@@ -12,64 +12,6 @@ How easy is the template to use?
 How flexible is it?
 How's our documentation?
 
-## Gallery
-
-<kbd>
-  <a href="https://greenelab.github.io/lab-website-template/">
-    <img src="https://user-images.githubusercontent.com/8326331/140773232-0c0f0780-a6ae-4fea-838b-b68f117d8ba0.png" height="150px" />
-    <br>
-    Lab Website Template
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://tislab.org/">
-    <img src="https://user-images.githubusercontent.com/8326331/140774758-58d13120-c091-41ea-87e3-d2219a90f1d9.png" height="150px" />
-    <br>
-    Translational and Integrative Sciences Lab
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://greenelab.com/">
-    <img src="https://user-images.githubusercontent.com/8326331/140775456-aa6afad1-ba72-48f6-803e-279f8c1011e9.png" height="150px" />
-    <br>
-    Greene Lab
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://www.waysciencelab.com/">
-    <img src="https://user-images.githubusercontent.com/8326331/140776192-80a802d5-be4f-4aeb-b159-f473bbb10fbe.png" height="150px" />
-    <br>
-    Way Lab
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://fong-lab.github.io/">
-    <img src="https://user-images.githubusercontent.com/8326331/140777326-e1da4b0f-053b-4355-823d-077fc1078a5b.png" height="150px" />
-    <br>
-    Fong Lab
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://mmv-lab.github.io/">
-    <img src="https://user-images.githubusercontent.com/8326331/140778499-787f6d7f-f07f-43ee-9942-5ac8f955443a.png" height="150px" />
-    <br>
-    Microscopy Machine Vision Lab
-  </a>
-</kbd>
-
-<kbd>
-  <a href="https://quantmarineecolab.github.io/">
-    <img src="https://user-images.githubusercontent.com/8326331/140778904-42abe18d-bcbe-4861-8993-911c95e6b6f6.png" height="150px" />
-    <br>
-    Quantitative Marine Ecology Lab
-  </a>
-</kbd>
-
 ## Features
 
 - **Automatically generated citations** (using [Manubot](https://manubot.org)) from **just an identifier** (DOI, PubMed ID, and many more)
@@ -89,6 +31,10 @@ How's our documentation?
 - A **team** page, compiled automatically from individual members
 - Individual **team member pages** with bios, assignable roles, and social media links
 - A **blog page**, with a sorted, grouped, tagged list of all your posts
+
+## Gallery
+
+[🖼️ See who else is using the template and what it can do!](https://github.com/greenelab/lab-website-template/wiki/Gallery)
 
 ## Documentation
 

--- a/_config.yaml
+++ b/_config.yaml
@@ -17,6 +17,8 @@ links:
   instagram: YourLabHandle
   youtube: YourLabChannel
 
+### advanced settings
+
 # automatic citations
 auto-cite:
   plugins:
@@ -24,8 +26,6 @@ auto-cite:
       input:
         - ../_data/sources.yaml
   output: ../_data/citations.yaml
-
-### advanced settings
 
 # default front matter parameters for markdown files
 defaults:

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,3 +1,8 @@
 {::nomarkdown}
-<img class="banner" src="{{ include.image | relative_url }}" loading="lazy" />
+<img
+  class="banner"
+  src="{{ include.image | relative_url }}"
+  loading="lazy"
+  alt=""
+/>
 {:/}

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -3,6 +3,6 @@
   class="banner"
   src="{{ include.image | relative_url }}"
   loading="lazy"
-  alt=""
+  alt="Banner image"
 />
 {:/}

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,1 +1,3 @@
+{::nomarkdown}
 <img class="banner" src="{{ include.image | relative_url }}" loading="lazy" />
+{:/}

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -19,6 +19,7 @@
       src="{{ include.image | relative_url }}"
       onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
       loading="lazy"
+      alt=""
     >
   </{{ tag }}>
   <span class="card_text">

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -28,6 +28,7 @@
           onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
           data-tooltip="{{ id }}"
           loading="lazy"
+          alt=""
         >
       </a>
     </div>

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -28,7 +28,7 @@
           onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
           data-tooltip="{{ id }}"
           loading="lazy"
-          alt=""
+          alt="Citation thumbnail"
         >
       </a>
     </div>

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -35,16 +35,11 @@
 
     <section
       class="background"
+      {% if full %}data-full="true"{% endif %}
       {% if dark %}data-dark="true"{% endif %}
       {% if background %}style="--background: url('{{ background | relative_url }}')"{% endif %}
     >
-      {%- if full == false -%}
-      <div class="section">
-      {%- endif -%}
-        {{ section }}
-      {%- if full == false -%}
-      </div>
-      {%- endif -%}
+      {{- section -}}
     </section>
 
   {%- endunless -%}

--- a/_includes/feature.html
+++ b/_includes/feature.html
@@ -3,7 +3,7 @@
     {% if include.link %}href="{{ include.link | relative_url }}"{% endif %}
     class="feature_image"
   >
-    <img src="{{ include.image | relative_url }}" loading="lazy" alt="{{ include.headline | default: '' }}" />
+    <img src="{{ include.image | relative_url }}" loading="lazy" alt="" />
   </a>
   <div class="feature_text">
     {%- if include.headline -%}

--- a/_includes/feature.html
+++ b/_includes/feature.html
@@ -3,7 +3,7 @@
     {% if include.link %}href="{{ include.link | relative_url }}"{% endif %}
     class="feature_image"
   >
-    <img src="{{ include.image | relative_url }}" loading="lazy" />
+    <img src="{{ include.image | relative_url }}" loading="lazy" alt="{{ include.headline | default: '' }}" />
   </a>
   <div class="feature_text">
     {%- if include.headline -%}

--- a/_includes/feature.html
+++ b/_includes/feature.html
@@ -3,7 +3,11 @@
     {% if include.link %}href="{{ include.link | relative_url }}"{% endif %}
     class="feature_image"
   >
-    <img src="{{ include.image | relative_url }}" loading="lazy" alt="" />
+    <img
+      src="{{ include.image | relative_url }}"
+      loading="lazy"
+      alt=""
+    />
   </a>
   <div class="feature_text">
     {%- if include.headline -%}

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -50,8 +50,8 @@
   >
     <img
       src="{{ include.image | relative_url }}"
-      alt="{{ include.caption }}"
-      title="{{ include.caption }}"
+      alt="{{ include.caption | default: '' }}"
+      title="{{ include.caption | default: '' }}"
       style="{{ img }}"
       loading="lazy"
     />

--- a/_includes/fonts.html
+++ b/_includes/fonts.html
@@ -5,8 +5,16 @@
   rel="stylesheet"
 />
 
-<!-- Font Awesome (icons) -->
+<!-- Font Awesome icons (load asynchronously due to size) -->
 <link
   href="https://use.fontawesome.com/releases/v5.13.1/css/all.css"
-  rel="stylesheet"
+  rel="preload"
+  as="style"
+  onload="this.onload = null; this.rel = 'stylesheet';"
 />
+<noscript>
+  <link
+    href="https://use.fontawesome.com/releases/v5.13.1/css/all.css"
+    rel="stylesheet"
+  />
+</noscript>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,6 +12,13 @@
 {%- endif -%}
 
 <footer {% if background %}class="background"{% endif %} {% if background %}style="--background: url('{{ background | relative_url }}')"{% endif %} data-dark="{{ dark }}">
+
+  <!--
+  <div class="footer_row">
+    Extra details like contact info or address
+  </div>
+  -->
+
   <div class="footer_row">
     {%- for entry in site.links -%}
       {%- assign key = entry[0] -%}
@@ -19,9 +26,13 @@
       {%- include link.html type=key icon="" tooltip="" link=value -%}
     {%- endfor -%}
   </div>
-  <!--
+
   <div class="footer_row">
-    &copy; {{ site.time | date: '%Y' }} {{ site.title }}
+    <span>
+      &copy; {{ site.time | date: '%Y' }} {{ site.title }}
+      &nbsp; | &nbsp;
+      Built with <a href="https://github.com/greenelab/lab-website-template">Lab Website Template</a>
+    </span>
   </div>
-  -->
+
 </footer>

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -24,7 +24,11 @@
         class="gallery_item"
         data-tooltip="{{ tooltip }}"
       >
-        <img src="{{ image | relative_url }}" loading="lazy">
+        <img
+          src="{{ image | relative_url }}"
+          loading="lazy"
+          alt="{{ tooltip | default: ''  }}"
+        />
       </a>
     {%- endif -%}
 

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -22,12 +22,12 @@
       <a
         {% if link %}href="{{ link | relative_url }}"{% endif %}
         class="gallery_item"
-        data-tooltip="{{ tooltip }}"
+        data-tooltip="{{ tooltip | default: '' }}"
       >
         <img
           src="{{ image | relative_url }}"
           loading="lazy"
-          alt="{{ tooltip | default: ''  }}"
+          alt=""
         />
       </a>
     {%- endif -%}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,9 +1,5 @@
 <head>
   {% include analytics.html %}
-  <title>
-    {{ site.title }}{% if page.title %} - {% endif %}{{ page.title }}
-  </title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
   {% include meta.html %}
   {% include favicons.html %}
   {% include fonts.html %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,10 +11,6 @@
   {%- assign dark = true -%}
 {%- endif -%}
 
-{%- assign title = site.logo-text -%}
-{%- if title == nil -%}
-  {%- assign title = site.title -%}
-{%- endif -%}
 
 <header {% if background %}class="background"{% endif %} {% if background %}style="--background: url('{{ background | relative_url }}')"{% endif %} data-dark="{{ dark }}">
   <a
@@ -22,9 +18,9 @@
     class="logo_row"
     data-tooltip="Home"
   >
-    <img src="{{ site.logo | relative_url }}" class="logo" />
-    {% if title and title != "" %}
-      <span class="logo_text">{{ title }}</span>
+    <img src="{{ site.logo | relative_url }}" class="logo" alt="{{ site.title }}" />
+    {% if site.logo-text != false %}
+      <span class="logo_text">{{ site.title }}</span>
     {% endif %}
   </a>
   <nav class="nav_row">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
     class="logo_row"
     data-tooltip="Home"
   >
-    <img src="{{ site.logo | relative_url }}" class="logo" alt="{{ site.title }}" />
+    <img src="{{ site.logo | relative_url }}" class="logo" alt="Logo image" />
     {% if site.logo-text != false %}
       <span class="logo_text">{{ site.title }}</span>
     {% endif %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,6 +1,15 @@
-{% capture title%}
-{{ site.title }}{% if page.title %} - {% endif %}{{ page.title }}
-{% endcapture %}
+{% assign title = "" | split: "," %}
+{% if site.title %}
+  {% assign title = title | push: site.title %}
+{% endif %}
+{% if page.title %}
+  {% assign title = title | push: page.title %}
+{% endif %}
+{% assign title = title | join: " - " %}
+
+<title>{{ title }}</title>
+
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <!-- https://metatags.io/ -->
 <meta name="title" content="{{ title }}" />

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -26,18 +26,18 @@
   {%- if role -%}
     {%- include role.html type=role -%}
   {%- endif -%}
-
+  
+  {%- assign name = member.name | default: "" -%}
   {%- assign image = member.image | default: "" -%}
   <span class="portrait_image">
     <img
       src="{{ image | relative_url }}"
       onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
       loading="lazy"
-      alt=""
+      alt="{{ name | default: 'Member portrait' }}"
     >
   </span>
 
-  {%- assign name = member.name | default: "" -%}
   {%- if name -%}
     <span class="portrait_name">
       {{ name }}

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -33,6 +33,7 @@
       src="{{ image | relative_url }}"
       onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
       loading="lazy"
+      alt=""
     >
   </span>
 

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -16,14 +16,12 @@
     <a href="{{ url | relative_url }}">{{ title }}</a>
   </p>
 
-  {% assign author = post.author | default: "" %}
-  {% assign tags = post.tags | default: emptyarray %}
-  {% assign date = post.date | default: "" %}
   {%
     include post-info.html
-    author=author
-    tags=tags
-    date=date
+    author=post.author
+    member=post.member
+    date=post.date
+    tags=post.tags
   %}
 
   {% assign content = post.content | default: "" %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,11 +1,11 @@
 <!-- third party scripts -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/mark.min.js"></script>
+<script src="https://unpkg.com/@popperjs/core@2" defer></script>
+<script src="https://unpkg.com/tippy.js@6" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/mark.min.js" async></script>
 
 <!-- site-wide javascript scripts -->
 {% for file in site.static_files %}
   {%- if file.path contains "/js" -%}
-    <script src="{{ file.path | relative_url }}"></script>
+    <script src="{{ file.path | relative_url }}" defer></script>
   {% endif -%}
 {% endfor %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <!-- third party scripts -->
 <script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://unpkg.com/tippy.js@6"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/mark.min.js"></script>
 
 <!-- site-wide javascript scripts -->

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,7 +1,10 @@
 <!-- third party scripts -->
 <script src="https://unpkg.com/@popperjs/core@2" defer></script>
 <script src="https://unpkg.com/tippy.js@6" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/mark.min.js" async></script>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/mark.min.js"
+  defer
+></script>
 
 <!-- site-wide javascript scripts -->
 {% for file in site.static_files %}

--- a/_includes/search-box.html
+++ b/_includes/search-box.html
@@ -1,5 +1,10 @@
 <div class="search_box">
-  <input class="search_input" oninput="onSearchInput(this)" placeholder="Search" />
+  <input
+    class="search_input"
+    oninput="onSearchInput(this)"
+    placeholder="Search"
+    title="Search content on this page"
+  />
   <button disabled data-tooltip="Clear search" onclick="onSearchClear()">
     <i class="fas fa-search"></i>
   </button>

--- a/_includes/site-search.html
+++ b/_includes/site-search.html
@@ -1,6 +1,7 @@
 <form
   onsubmit="onSiteSearchSubmit(event)"
   data-site="{{ '' | absolute_url }}"
+  title="Search site with Google"
 >
   <input type="text" name="query" placeholder="Search site" />
   <button type="submit">

--- a/_includes/site-search.html
+++ b/_includes/site-search.html
@@ -1,8 +1,4 @@
-<form
-  onsubmit="onSiteSearchSubmit(event)"
-  data-site="{{ '' | absolute_url }}"
-  title="Search site with Google"
->
+<form onsubmit="onSiteSearchSubmit(event)" title="Search site with Google">
   <input type="text" name="query" placeholder="Search site" />
   <button type="submit">
     <i class="fas fa-search"></i>

--- a/_includes/site-search.html
+++ b/_includes/site-search.html
@@ -1,0 +1,9 @@
+<form
+  onsubmit="onSiteSearchSubmit(event)"
+  data-site="{{ '' | absolute_url }}"
+>
+  <input type="text" name="query" placeholder="Search site" />
+  <button type="submit">
+    <i class="fas fa-search"></i>
+  </button>
+</form>

--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -1,4 +1,12 @@
-{%- assign tags = include.tags | join: "," | split: "," -%}
+{%- assign tags = "" | split: "," -%}
+{%- assign input = include.tags | join: "," | split: "," -%}
+{%- for tag in input -%}
+  {%- assign tag = tag | strip -%}
+  {%- if tag != "" -%}
+    {%- assign tags = tags | push: tag -%}
+  {%- endif -%}
+{%- endfor -%}
+
 {%- assign repo = include.repo | strip -%}
 {%- if repo == "" -%}
   {%- assign repo = nil -%}

--- a/_includes/tooltip.html
+++ b/_includes/tooltip.html
@@ -1,4 +1,0 @@
-<div class="tooltip">
-  <div class="tooltip_content"></div>
-  <div class="tooltip_arrow" data-popper-arrow></div>
-</div>

--- a/_includes/two-col.html
+++ b/_includes/two-col.html
@@ -1,4 +1,4 @@
 <div class="two_col">
-  <div>{{ include.col1 }}</div>
-  <div>{{ include.col2 }}</div>
+  <div>{{ include.col1 | markdownify }}</div>
+  <div>{{ include.col2 | markdownify }}</div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="us">
   {% include head.html %}
   <body>
     {% include header.html %}
@@ -6,6 +7,5 @@
       {% include content.html content=content %}
     </main>
     {% include footer.html %}
-    {% include tooltip.html %}
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="us">
+<html lang="en">
   {% include head.html %}
   <body>
     {% include header.html %}

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -40,7 +40,6 @@ layout: default
   {{ page.title }}'s papers
 {%- endcapture -%}
 
-
 <p class="center">
   {%- include link.html icon="fas fa-book-open" text=text link=search style="button" -%}
 </p>

--- a/_posts/2020-07-02-example-post-3.md
+++ b/_posts/2020-07-02-example-post-3.md
@@ -1,8 +1,6 @@
 ---
 title: Example post 3
-tags: 
-  - biology
-  - medicine
+tags: biology, medicine
 author: Upton O. Goode
 member: upton-goode
 ---

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -6,7 +6,7 @@ config = {}
 try:
     config = load_data("../_config.yaml", type_check=False).get("auto-cite")
     if not config:
-        raise Exception("Couldn't find auto-cite config")
+        raise Exception("Couldn't find auto-cite key in config")
 except Exception as message:
     log(message, 3, "red")
     exit(1)

--- a/cite.sh
+++ b/cite.sh
@@ -1,1 +1,0 @@
-python ./auto-cite/auto-cite.py

--- a/css/banner.scss
+++ b/css/banner.scss
@@ -6,5 +6,6 @@
 @import "mixins";
 
 .banner {
+  display: block;
   width: 100%;
 }

--- a/css/button.scss
+++ b/css/button.scss
@@ -1,0 +1,25 @@
+---
+---
+
+@import "palettes";
+@import "theme";
+@import "mixins";
+
+button {
+  @include inline-flex-center;
+  max-width: calc(100% - 10px - 10px);
+  min-height: 40px;
+  margin: 0;
+  padding: 7.5px 15px;
+  border: none;
+  border-radius: 5px;
+  background: $accent;
+  color: $white;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background $fast;
+
+  &:hover {
+    background: $gray-500;
+  }
+}

--- a/css/feature.scss
+++ b/css/feature.scss
@@ -18,10 +18,10 @@
     img {
       width: 100%;
     }
+  }
 
-    .feature_text {
-      flex-grow: 1;
-    }
+  .feature_text {
+    flex-grow: 1;
   }
 
   &:nth-child(odd) {

--- a/css/feature.scss
+++ b/css/feature.scss
@@ -18,6 +18,10 @@
     img {
       width: 100%;
     }
+
+    .feature_text {
+      flex-grow: 1;
+    }
   }
 
   &:nth-child(odd) {
@@ -46,13 +50,13 @@
 
     .feature_image {
       order: unset !important;
-      width: unset !important;
+      width: unset;
       margin: 0 !important;
       margin-bottom: 20px !important;
+    }
 
-      .feature_text {
-        width: unset !important;
-      }
+    .feature_text {
+      width: 100%;
     }
   }
 }

--- a/css/footer.scss
+++ b/css/footer.scss
@@ -21,6 +21,7 @@ footer {
     flex-wrap: wrap;
     margin: 20px 0;
     @include trim-v-margins;
+    line-height: $spacing + 0.3;
 
     &:hover .link {
       opacity: 0.25;
@@ -33,6 +34,5 @@ footer {
 
   a {
     color: currentColor;
-    text-decoration: none;
   }
 }

--- a/css/form.scss
+++ b/css/form.scss
@@ -1,0 +1,13 @@
+---
+---
+
+@import "palettes";
+@import "theme";
+@import "mixins";
+
+form {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}

--- a/css/header.scss
+++ b/css/header.scss
@@ -41,6 +41,10 @@ header {
     text-transform: uppercase;
     letter-spacing: 1px;
 
+    .link {
+      margin: 0 10px;
+    }
+
     &:hover .link {
       opacity: 0.25;
     }

--- a/css/header.scss
+++ b/css/header.scss
@@ -60,7 +60,7 @@ header {
   }
 
   // screen width where nav bar wraps to under logo
-  // adjust based on width of your lab name and width of your nav bar
+  // adjust based on width of your lab name and nav bar
   @media (max-width: 1000px) {
     align-content: center;
 
@@ -71,7 +71,7 @@ header {
   }
 
   // screen width where logo and nav bar go from horizontal to vertical
-  // adjust based on width of your lab name and width of your nav bar
+  // adjust based on width of your lab name and nav bar
   @media (max-width: 700px) {
     .logo_row {
       flex-direction: column;

--- a/css/header.scss
+++ b/css/header.scss
@@ -36,7 +36,7 @@ header {
 
   .nav_row {
     @include inline-flex-center;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: $regular;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -56,8 +56,8 @@ header {
   }
 
   // screen width where nav bar wraps to under logo
-  // adjust based on length of your lab title and # of nav links
-  @media (max-width: 900px) {
+  // adjust based on width of your lab name and width of your nav bar
+  @media (max-width: 1000px) {
     align-content: center;
 
     .logo_row,
@@ -67,8 +67,8 @@ header {
   }
 
   // screen width where logo and nav bar go from horizontal to vertical
-  // adjust based on length of your lab title and # of nav links
-  @media (max-width: 600px) {
+  // adjust based on width of your lab name and width of your nav bar
+  @media (max-width: 700px) {
     .logo_row {
       flex-direction: column;
     }

--- a/css/input.scss
+++ b/css/input.scss
@@ -8,11 +8,11 @@
 input {
   width: $page / 3;
   height: 40px;
-  max-width: calc(100% - 10px - 10px);
-  margin: 10px;
+  max-width: 100%;
+  margin: 0;
   padding: 5px 10px;
   border: solid 1px $gray-800;
   border-radius: 5px;
   font-family: $sans;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }

--- a/css/link.scss
+++ b/css/link.scss
@@ -17,7 +17,8 @@ a:hover {
 .link {
   @include inline-flex-center;
   max-width: 100%;
-  padding: 10px;
+  margin: 5px;
+  padding: 5px;
   font-size: 0.9rem;
   text-decoration: none;
   vertical-align: bottom;

--- a/css/link.scss
+++ b/css/link.scss
@@ -19,7 +19,7 @@ a:hover {
   max-width: 100%;
   margin: 5px;
   padding: 5px;
-  font-size: 0.9rem;
+  font-size: 1rem;
   text-decoration: none;
   vertical-align: bottom;
   transition: background $fast, color $fast, opacity $fast;

--- a/css/mixins.scss
+++ b/css/mixins.scss
@@ -12,6 +12,16 @@
   align-items: center;
 }
 
+@mixin trim-h-margins {
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
 @mixin trim-v-margins {
   &:first-child {
     margin-top: 0;

--- a/css/portrait.scss
+++ b/css/portrait.scss
@@ -33,7 +33,7 @@
   .portrait_name,
   .portrait_description {
     font-family: $sans;
-    font-size: 0.9rem;
+    font-size: 1rem;
   }
 
   .portrait_name {

--- a/css/section.scss
+++ b/css/section.scss
@@ -39,7 +39,7 @@ body {
   }
 
   section:nth-of-type(even) {
-    background: $gray-100;
+    background: $gray-50;
   }
 
   section:last-of-type {

--- a/css/section.scss
+++ b/css/section.scss
@@ -24,12 +24,13 @@ body {
   }
 
   section {
-    .section {
-      box-sizing: content-box;
-      max-width: $page;
-      margin: 0 auto;
-      padding: 60px 40px;
-      text-align: center;
+    box-sizing: content-box;
+    padding: 60px 40px;
+    padding: 60px Max(40px, calc((100% - #{$page}) / 2));
+    text-align: center;
+
+    &[data-full="true"] {
+      padding: 0;
     }
   }
 

--- a/css/section.scss
+++ b/css/section.scss
@@ -25,7 +25,7 @@ body {
 
   section {
     box-sizing: content-box;
-    padding: 60px 40px;
+    padding: 60px 40px; // fallback
     padding: 60px Max(40px, calc((100% - #{$page}) / 2));
     text-align: center;
 

--- a/css/tooltip.scss
+++ b/css/tooltip.scss
@@ -5,59 +5,9 @@
 @import "theme";
 @import "mixins";
 
-@import "theme";
 
-$arrow: 10px;
-
-.tooltip {
-  position: absolute;
-  left: -9999px;
-  top: -9999px;
-  max-width: calc(100vw - 40px);
-  padding: 10px 15px;
-  background: $black;
-  color: $white;
-  border-radius: 5px;
+.tippy-box {
   font-family: $sans;
-  font-size: 0.9rem;
-  opacity: 0;
-  z-index: 10;
-  pointer-events: none;
-  transition: opacity $fast;
-
-  &[data-show="true"] {
-    opacity: 1;
-  }
-
-  .tooltip_arrow {
-    position: absolute;
-    width: $arrow;
-    height: $arrow;
-  }
-
-  .tooltip_arrow:after {
-    content: "";
-    position: absolute;
-    width: $arrow;
-    height: $arrow;
-    background: $black;
-    transform: rotate(45deg);
-    z-index: -1;
-  }
-
-  &[data-popper-placement="top"] .tooltip_arrow {
-    bottom: -0.5 * $arrow;
-  }
-
-  &[data-popper-placement="bottom"] .tooltip_arrow {
-    top: -0.5 * $arrow;
-  }
-
-  &[data-popper-placement="left"] .tooltip_arrow {
-    right: -0.5 * $arrow;
-  }
-
-  &[data-popper-placement="right"] .tooltip_arrow {
-    left: -0.5 * $arrow;
-  }
+  padding: 10px;
+  font-size: 1rem;
 }

--- a/css/two-col.scss
+++ b/css/two-col.scss
@@ -8,7 +8,7 @@
 .two_col {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap: 20px;
+  grid-gap: 40px;
 
   @media (max-width: $phone) {
     grid-template-columns: 1fr;

--- a/index.md
+++ b/index.md
@@ -34,8 +34,7 @@ Spend less time reinventing the wheel, and more time running your lab.
 # Highlights
 
 {% capture text %}
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Lorem ipsum
 
 [See what we've published &nbsp;→](research)
 {:.center}

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: Home
 
 [Lab Website Template](https://github.com/greenelab/lab-website-template) is an easy-to-use, flexible website template for [labs](https://www.greenelab.com/), with automatic citations, GitHub tag imports, pre-built components, and more.
 Spend less time reinventing the wheel, and more time running your lab.
-  
+
 {%
   include link.html
   type="github"
@@ -34,7 +34,8 @@ Spend less time reinventing the wheel, and more time running your lab.
 # Highlights
 
 {% capture text %}
-Lorem ipsum
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 [See what we've published &nbsp;→](research)
 {:.center}
@@ -78,3 +79,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
   headline="Our Team"
   text=text
 %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/js/anchors.js
+++ b/js/anchors.js
@@ -10,15 +10,14 @@ const createAnchors = () => {
     const link = document.createElement("a");
     link.classList.add("fas", "fa-link", "anchor");
     link.href = "#" + heading.id;
+    link.setAttribute("aria-label", "Link to this section");
     heading.append(link);
 
     // if first heading in the section, move id from heading to parent section
-    if (heading.matches(":first-child")) {
-      let section = heading.closest("section");
-      if (section) {
-        section.id = heading.id;
-        heading.removeAttribute("id");
-      }
+    const parent = heading.parentElement;
+    if (parent.matches("section")) {
+      parent.id = heading.id;
+      heading.removeAttribute("id");
     }
   }
 };

--- a/js/site-search.js
+++ b/js/site-search.js
@@ -5,7 +5,7 @@
 const onSiteSearchSubmit = (event) => {
   event.preventDefault();
   const google = "https://www.google.com/search?q=site:";
-  const site = event.target.getAttribute("data-site");
+  const site = window.location.href;
   const query = event.target.elements.query.value;
   window.location = google + site + " " + query;
 };

--- a/js/site-search.js
+++ b/js/site-search.js
@@ -5,7 +5,7 @@
 const onSiteSearchSubmit = (event) => {
   event.preventDefault();
   const google = "https://www.google.com/search?q=site:";
-  const site = window.location.href;
+  const site = window.location.origin;
   const query = event.target.elements.query.value;
   window.location = google + site + " " + query;
 };

--- a/js/site-search.js
+++ b/js/site-search.js
@@ -1,0 +1,11 @@
+// search plugin
+// supports site search component which searches site/domain via google
+
+// when submits site search form/box
+const onSiteSearchSubmit = (event) => {
+  event.preventDefault();
+  const google = "https://www.google.com/search?q=site:";
+  const site = event.target.getAttribute("data-site");
+  const query = event.target.elements.query.value;
+  window.location = google + site + " " + query;
+};

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -1,76 +1,18 @@
 // tooltips plugin
 // shows a popup of text on hover/focus of an element
 
-// specify text to show in data-tooltip attribute
-// specify placement (top, bottom, left, right) in data-placement attribute
-// specify custom delay (in ms) in data-delay attribute
-
-const defaultPlacement = "top";
-const defaultDelay = 200;
-
 // create tooltip listener on any element with a data-tooltip attribute
 const createTooltips = () => {
-  // make sure Popper library available
-  if (typeof Popper === "undefined") return;
+  // make sure tippy library available
+  if (typeof tippy === "undefined") return;
 
-  // get tooltip element
-  const tooltip = document.querySelector(".tooltip");
-
-  // init popper.js library
-  let popper = null;
-  let options = ({ placement = defaultPlacement }) => ({
-    placement,
-    modifiers: [
-      // https://github.com/popperjs/popper-core/issues/1138
-      { name: "computeStyles", options: { adaptive: false } },
-      { name: "offset", options: { offset: [0, 10] } },
-      { name: "arrow", options: { padding: 10 } },
-    ],
+  tippy("[data-tooltip]", {
+    content: (element) => {
+      const content = element.getAttribute("data-tooltip");
+      element.setAttribute("aria-label", content);
+      return content;
+    },
   });
-
-  // open tooltip after delay
-  let timer;
-  const delayedOpen = ({ target }) => {
-    const delay = target.dataset.delay || defaultDelay;
-    window.clearTimeout(timer);
-    timer = window.setTimeout(() => open({ target }), delay);
-  };
-
-  // open tooltip on specified target
-  const open = ({ target }) => {
-    if (popper) popper.destroy();
-    popper = Popper.createPopper(target, tooltip, options(target.dataset));
-    tooltip.style.display = "";
-    tooltip.dataset.show = true;
-    tooltip.querySelector(".tooltip_content").innerHTML =
-      target.dataset.tooltip;
-  };
-
-  // close tooltip
-  const close = () => {
-    window.clearTimeout(timer);
-    tooltip.dataset.show = false;
-    tooltip.addEventListener(
-      "transitionend",
-      () => (tooltip.style.display = "none"),
-      { once: true }
-    );
-  };
-
-  // loop through elements with data-tooltip attribute
-  const targets = document.querySelectorAll("[data-tooltip]");
-  for (const target of targets) {
-    // if data-tooltip attribute is not empty
-    if ((target.dataset.tooltip || "").trim()) {
-      // add triggers to target
-      target.addEventListener("mouseenter", delayedOpen);
-      target.addEventListener("focus", delayedOpen);
-      target.addEventListener("mouseleave", close);
-      target.addEventListener("blur", close);
-      // add aria label for extra accessibility
-      target.setAttribute("aria-label", target.dataset.tooltip);
-    }
-  }
 };
 
 // start script

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,0 @@
-bundle && bundle exec jekyll serve --trace --open-url --livereload

--- a/team/index.md
+++ b/team/index.md
@@ -39,13 +39,19 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
-{%
-  include link.html
-  icon="fas fa-hands-helping"
-  text="Join the Team"
-  link="join"
-  style="button"
-%}
+{% include section.html %}
+
+## Join
+
+#### Post Dogtoral Researcher
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+- 3+ (dog) years experience managing bone portfolios
+- Strong desire to learn tricks and go on walkies
+- Aptitude to sit and stay
+
+{% include link.html type="external" link="https://google.com/" text="Apply Now" icon="" style="button" %}
 {:.center}
 
 {% include section.html %}


### PR DESCRIPTION
closes #95 
closes #98 
closes #101 
closes #102 

- take site-wide google search on 404 page and make it into reusable component (see #2)
- remove gallery from readme (since we'll be want to update it somewhat regularly) and move to wiki
- set `img` alt attributes as appropriate
- refactor sections to be only one html element
- load font awesome async for performance
- add spots for extra details in footer, and add ad for template
- move some basic items in head to meta
- turn logo-text config option into simple boolean
- fix small blog post excerpt bug
- defer load all scripts
- move from popper.js to tippy.js for tooltips
- add accessible label to search box
- make tags component accept list or comma-separated values more robustly
- fix two col component bug where it can't accept markdown
- add html doctype and lang to prevent warnings and various issues
- remove bash scripts that no-one should probably be using, and are documented in the wiki anyway
- various css tweaks
- add aria labels to anchors
- fix anchor move-to-parent bug
- on team page, replace dead link to non-existent join page with just some job positing filler details (see #86 for discussion)
- test each page with lighthouse (in chrome dev tools), mobile and desktop