### PR TITLE
tweak manubot log level

### DIFF
--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -76,7 +76,7 @@ for index, source in enumerate(sources):
         try:
             new_citations.append(cite_with_manubot(source))
         except Exception as message:
-            log(message, 3, "")
+            log(message, 3, "red")
             exit(1)
 
 log("Exporting citations")

--- a/auto-cite/util.py
+++ b/auto-cite/util.py
@@ -144,7 +144,8 @@ def cite_with_manubot(source):
         print(palette['gray'])
         output = subprocess.Popen(commands, stdout=subprocess.PIPE).communicate()
         print(palette['reset'])
-    except Exception:
+    except Exception as error:
+        log(error, 3, "gray")
         raise Exception("Manubot could not generate citation")
     
     # parse results as json

--- a/auto-cite/util.py
+++ b/auto-cite/util.py
@@ -21,10 +21,10 @@ os.system("")
 # colors for logging
 palette = {
     "white": "\033[97m",
+    "gray": "\033[90m",
     "red": "\033[91m",
     "green": "\033[92m",
     "yellow": "\033[93m",
-    "blue": "\033[94m",
     "purple": "\033[95m",
     "cyan": "\033[96m",
     "reset": "\033[0m",
@@ -38,13 +38,10 @@ def log(message="", level=1, color=""):
     if not color:
         color = levels[level]
 
-    if color != "white":
-        print("")
-
     if level == 1:
         message = message.upper()
 
-    print(f"{(level - 1) * '  '}{palette[color]}{message}{palette['reset']}")
+    print(f"{(level - 1) * '  '}{palette[color]}{message}{palette['reset']}\n")
 
 
 # find item in list that matches entry by id
@@ -141,13 +138,20 @@ def cite_with_manubot(source):
     # source id
     id = source.get("id")
 
-    # run Manubot and get results as json
+    # run Manubot and get results
     try:
-        commands = ["manubot", "cite", id, "--log-level=ERROR"]
-        output = subprocess.Popen(commands, stdout=subprocess.PIPE)
-        manubot = json.loads(output.communicate()[0])[0]
+        commands = ["manubot", "cite", id, "--log-level=WARNING"]
+        print(palette['gray'])
+        output = subprocess.Popen(commands, stdout=subprocess.PIPE).communicate()
+        print(palette['reset'])
     except Exception:
         raise Exception("Manubot could not generate citation")
+    
+    # parse results as json
+    try:
+        manubot = json.loads(output[0])[0]
+    except Exception:
+        raise Exception("Couldn't parse Manubot response")
 
     # new citation info, with only needed info from Manubot
     citation = {}

--- a/js/search.js
+++ b/js/search.js
@@ -120,13 +120,13 @@ const updateBox = (query = "") => {
 // update search results info
 const updateInfo = (query, x, n) => {
   // hide all info boxes
-  window.trueHide(infoSelector);
+  trueHide(infoSelector);
 
   // hide info if nothing searched
   if (!query.trim()) return;
 
   // show
-  window.trueShow(infoSelector);
+  trueShow(infoSelector);
 
   // info template
   let info = "";

--- a/js/true-hide.js
+++ b/js/true-hide.js
@@ -1,5 +1,4 @@
 // true hide plugin
-// "truly" hide an element by removing it from the dom
 
 // css "display: none" removes an element from the document flow, but does not
 // remove it from the dom. the result is that css selectors like ":first-child"
@@ -7,32 +6,32 @@
 // removing the node from the dom. this is hacky. use with care.
 
 // store to hold removed nodes for later re-insertion
-window.nodeStore = {};
+const nodeStore = {};
 // counter to create unique ids for nodes
-window.nodeId = 0;
+let nodeId = 0;
 // id prefix to avoid collision with comments outside of this plugin
 const prefix = "true-hide-";
 
 // hide all elements that match query
-window.trueHide = (query) => {
+const trueHide = (query) => {
   // loop through elements matching query
   const elements = document.querySelectorAll(query);
   for (const element of elements) {
     // replace node with comment
-    const comment = document.createComment(prefix + window.nodeId);
+    const comment = document.createComment(prefix + nodeId);
     element.parentNode.insertBefore(comment, element.nextSibling);
     const node = element.parentElement.removeChild(element);
 
     // add node to list of removed nodes
-    window.nodeStore[window.nodeId] = node;
-    window.nodeId++;
+    nodeStore[nodeId] = node;
+    nodeId++;
   }
 };
 
 // show previously hidden elements that match query
-window.trueShow = (query) => {
+const trueShow = (query) => {
   // loop through previously removed nodes
-  for (const [id, node] of Object.entries(window.nodeStore)) {
+  for (const [id, node] of Object.entries(nodeStore)) {
     // ignore nodes that don't match query
     if (!node.matches(query)) continue;
 
@@ -49,7 +48,7 @@ window.trueShow = (query) => {
       if (comment.textContent === prefix + id) {
         comment.parentNode.insertBefore(node, comment);
         comment.remove();
-        delete window.nodeStore[id];
+        delete nodeStore[id];
       }
     }
   }


### PR DESCRIPTION
Closes #112 

- increase manubot log level to "warning" to show message when an invalid identifier type is used
- force manubot logging to gray color
- rearrange `try` blocks around manubot call for a bit better distinction between errors
- make trueHide/trueShow util funcs just be locally `<script>` scoped (like the other util functions) rather than attached to `window`