### PR TITLE
update citation component to support id-less

### DIFF
--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -1,14 +1,19 @@
 {%- assign emptyarray = "" | split: "," -%}
-{%- assign id = include.id | default: "" -%}
 {%- assign output = site.auto-cite.output | default: "citations" | split: "/" | last | split: "." | pop | join: "" -%}
 {%- assign citations = site.data[output] | default: emptyarray -%} 
 
 {%- assign citation = nil -%}
 {%- for c in citations -%}
-  {%- if c.id == id -%}
+  {%- if c.id == include.lookup or c.title contains include.lookup -%}
     {%- assign citation = c -%}
+    {%- break -%}
   {%- endif -%}
 {%- endfor -%}
+
+{%- if citation -%}
+{%- else -%}
+  {%- assign citation = include -%}
+{%- endif -%}
 
 {%- assign rich = false -%}
 {%- if include.style == "rich" -%}
@@ -18,6 +23,7 @@
 {%- assign placeholder = "images/placeholder.svg" | relative_url -%}
 
 <div class="citation" data-style="{{ include.style }}">
+  {%- assign id = citation.id | default: "" -%}
   {%- assign link = citation.link | default: "" -%}
   {%- assign image = citation.image | default: "" -%}
   {%- if rich -%}

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -1,4 +1,5 @@
 {%- assign emptyarray = "" | split: "," -%}
+
 {%- assign data = site.data[include.data] | default: site[include.data] | default: emptyarray -%}
 {%- assign component = include.component | append: ".html" -%}
 
@@ -43,6 +44,7 @@
   {%-
     include {{ component }}
     author=d.author
+    authors=d.authors
     caption=d.caption
     content=d.content
     date=d.date
@@ -53,6 +55,7 @@
     id=d.id
     image=d.image
     link=link
+    publisher=d.publisher
     repo=d.repo
     role=d.role
     slug=d.slug

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,4 +1,6 @@
-{% assign title = "" | split: "," %}
+{% assign emptyarray = "" | split: "," %}
+
+{% assign title = emptyarray %}
 {% if site.title %}
   {% assign title = title | push: site.title %}
 {% endif %}

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -5,6 +5,7 @@
 {%- endif -%}
 
 {%- assign emptyarray = "" | split: "," -%}
+
 {%- assign id = include.slug | default: include.id | default: "" -%}
 {%- assign members = site.members | default: emptyarray -%} 
 

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -1,4 +1,5 @@
 {% assign emptyarray = "" | split: "," %}
+
 {% assign id = include.slug | default: include.id | default: "" %}
 {% assign posts = site.posts | default: emptyarray %}
 

--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -1,4 +1,6 @@
-{%- assign tags = "" | split: "," -%}
+{%- assign emptyarray = "" | split: "," -%}
+
+{%- assign tags = emptyarray -%}
 {%- assign input = include.tags | join: "," | split: "," -%}
 {%- for tag in input -%}
   {%- assign tag = tag | strip -%}


### PR DESCRIPTION
#120 made changes such that not having an `id` field in `sources.yaml` will still work and not throw a wrench in the auto-cite process. This PR makes it so that the citation component can actually display a source without an id, because currently it works by looking up a citation by id (because I was assuming every source would have an id). Docs have already been updated to reflect this change, and several tangential clarifications have been made.