### PR TITLE
utilize joblib.memory for auto-cite manubot cache

### DIFF
--- a/.github/workflows/auto-cite.yaml
+++ b/.github/workflows/auto-cite.yaml
@@ -23,6 +23,11 @@ jobs:
           python-version: 3.7
       - name: Install packages
         run: python -m pip install --upgrade --requirement ./auto-cite/requirements.txt
+      - name: Cache Manubot
+        uses: actions/cache@v3
+        with:
+          path: .manubot-cache
+          key: manubot-cache-1
       - name: Build updated citations
         run: python ./auto-cite/auto-cite.py
       - name: Commit updated citations

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 debug.log
 __pycache__/
 .DS_STORE
+.manubot-cache

--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -15,7 +15,6 @@
     link: https://greenelab.github.io/knowledge-graph-review/
   tags:
   - knowledge graphs
-  _cache: 371e391cc663116136dc43f4c93ebdc2998f52a3abd67c7add918c3b9f4f98d9
 - id: doi:10.1371/journal.pcbi.1007128
   title: Open collaborative writing with Manubot
   authors:
@@ -38,7 +37,6 @@
     link: https://github.com/greenelab/meta-review
   - type: website
     link: http://manubot.org/
-  _cache: 9b4d326347b4c43474de520edff579266c3c490e1baf4a2074ea151d6c90e318
 - id: doi:10.7554/eLife.32822
   title: Sci-Hub provides access to nearly all scholarly literature
   authors:
@@ -64,4 +62,3 @@
   - type: source
     link: https://github.com/greenelab/scihub
     text: Analyses source
-  _cache: 1510c88d1d7cdb29f090da47b0903118fa57243de166541c8ff31c614fc05604

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -1,6 +1,6 @@
 from util import *
 from importlib import import_module
-from dict_hash import sha256
+
 
 # config info for input/output files and plugins
 config = {}
@@ -45,8 +45,9 @@ for plugin in config.get("plugins", []):
         log(f"Got {len(plugin_sources)} sources", 2, "green")
 
         for source in plugin_sources:
-            # make unique key for cache matching
-            source["_cache"] = sha256({**source, "plugin": name, "input": file})
+            # attach additional metadata
+            # source["_plugin"] = name
+            # source["_input"] = file
             # add source
             sources.append(source)
 
@@ -70,25 +71,20 @@ for index, source in enumerate(sources):
     # new citation for source
     new_citation = {}
 
-    # find same source in existing citations
-    cached = get_cached(source, citations)
+    # get id of source
+    id = source.get("id", "").strip()
 
-    if cached:
-        # use existing citation to save time
-        log("Using existing citation", 3)
-        new_citation = cached
-
-    elif source.get("id", "").strip():
+    if id:
         # use Manubot to generate new citation
         log("Using Manubot to generate new citation", 3)
         try:
-            new_citation = cite_with_manubot(source)
+            new_citation = cite_source(id)
         except Exception as message:
             log(message, 3, "red")
             exit(1)
     else:
-        # pass source through untouched
-        log("Passing source through", 3)
+        # skip Manubot
+        log("No ID, skipping Manubot", 3)
 
     # merge in properties from input source
     new_citation.update(source)

--- a/auto-cite/requirements.txt
+++ b/auto-cite/requirements.txt
@@ -1,3 +1,3 @@
 manubot==0.5.3
 PyYAML==6.0
-dict-hash==1.1.26
+joblib==1.1.0


### PR DESCRIPTION
This PR makes the caching of citations work differently. Let's call the new way the "joblib" method, and the current way the "cache key" method.

---

Summary of how cache key works:

- first run of the script
- we compute the sha256 hash of the input source
- we use manubot to get the citation details for the source, which takes a while
- the results from manubot, along with the sha256, are saved to the output citations.yaml file
- subsequent run of the script
- we compute the sha256 hash of the input source
- we check the output citations.yaml file to see if any of the entries have the same hash (meaning they had to come from the same file and entry as last time)
- if we find a match, we use that existing info and skip running manubot. if not, we run manubot.

Summary of how joblib works:

- no funny hash computation (on our end), we just always run the "cite with manubot" code
- but the "cite with manubot" code is wrapped in an on-disk memoized function that immediately returns cached outputs given the same inputs, saving time (manubot doesn't actually run, and no network requests)
- the cache data is stored in the `.manubot-cache` folder for use on subsequent runs of the script

---

The question is, is this better? I'm thinking maybe.

Pros of joblib:

- no unwanted/confusing `_cache` keys in citations.yaml output file
- cleaner, at least in the python code. offloads the burden of hashing and cache matching to the library.
- less confusing as to why it's there. it's clear what we're doing, and why we need to do it. we're caching only the part of the process that is at all time consuming: running manubot. with cache key, it's much harder to understand without studying the code and reading my PR comments. this is quite a significant benefit, in my mind.

Cons of joblib:

- there doesn't seem to be a way to tell if a cached or uncached version of the function is running, and i'd really like to log which one it is for each source (e.g. "running manubot fresh" vs "using cached manubot response"). maybe there's a way to shim the library to make this possible, but i would need help with that.
- requires an extra action in the github actions workflow (which is the primary/recommended way to do auto citations) to support the cache folder
- cache no longer works across contexts. with cache key, the cache is in citations.yaml itself, which is tracked in the repo. with joblib, the cache is in a folder which cannot be tracked†. so for people building citations locally, that cache will not transfer over to when they are building citations on github actions. this is not a huge deal though. 
- cache is more hidden and opaque, and less explicit. having the cache be citations.yaml itself is pretty simple. with joblib, it is obfuscated in a special folder, one you might not even be able to see (in cache in github actions). this could possibly lead to more silent failures?
- similarly, cache is harder to clear on the github actions side. i have seen discussions and votes on the github actions "cache" action for having ways to conveniently inspect/clear/control/etc the cache, but i dont think those have been implemented yet. for now, to clear the cache, a user would have to be instructed to go into their `.github/workflows/auto-cite.yaml` file, and increment or otherwise change `key: manubot-cache-1`


† Well, _should_ not be tracked. It's much more verbose and data-duplication-y, which will confuse users and make for larger/messier diffs