### PR TITLE
Don't error exit code on metasource failure, and misc error handling improvements

### DIFF
--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -15,7 +15,7 @@
     link: https://greenelab.github.io/knowledge-graph-review/
   tags:
   - knowledge graphs
-  _cache: 371e391cc663116136dc43f4c93ebdc2998f52a3abd67c7add918c3b9f4f98d9
+  _cache: 2b8aa76c98be2f26481ab15dc135eb446fa9ef6f94af175c9639d1a45d538cf4
 - id: doi:10.1371/journal.pcbi.1007128
   title: Open collaborative writing with Manubot
   authors:
@@ -38,7 +38,7 @@
     link: https://github.com/greenelab/meta-review
   - type: website
     link: http://manubot.org/
-  _cache: 9b4d326347b4c43474de520edff579266c3c490e1baf4a2074ea151d6c90e318
+  _cache: 189b56e366896b6a90ae8d64fc4e605797d2bdd07674653d81ae533b2f1e4672
 - id: doi:10.7554/eLife.32822
   title: Sci-Hub provides access to nearly all scholarly literature
   authors:
@@ -64,4 +64,4 @@
   - type: source
     link: https://github.com/greenelab/scihub
     text: Analyses source
-  _cache: 1510c88d1d7cdb29f090da47b0903118fa57243de166541c8ff31c614fc05604
+  _cache: 483a564e9ddf847e6372cafb31de4673771c3e4da664c0d86a7ea7c38c20318d

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -23,8 +23,8 @@ will_exit = False
 # loop through plugins
 for plugin in config.get("plugins", []):
     # get plugin props
-    name = plugin.get("name", "-")
-    files = plugin.get("input", "")
+    name = plugin.get("name", "[no name]")
+    files = plugin.get("input", [])
 
     # show progress
     log(f"Running {name} plugin")
@@ -34,16 +34,15 @@ for plugin in config.get("plugins", []):
         # show progress
         log(file, 2)
 
-        # get data in file
-        data = []
+        plugin_sources = []
         try:
+            # get data in file
             data = load_data(file)
+            # run plugin
+            plugin_sources = import_module(f"plugins.{name}").main(data)
         except Exception as message:
             log(message, 3, "red")
             will_exit = True
-
-        # run plugin
-        plugin_sources = import_module(f"plugins.{name}").main(data)
 
         log(f"Got {len(plugin_sources)} sources", 2, "green")
 
@@ -58,7 +57,7 @@ for plugin in config.get("plugins", []):
 
 # exit at end of loop if error occurred
 if will_exit:
-    log("One or more input files failed to load", 3, "red")
+    log("One or more input files or plugins failed", 3, "red")
     exit(1)
 
 log("Generating citations for sources")
@@ -79,7 +78,7 @@ new_citations = []
 # go through sources
 for index, source in enumerate(sources):
     # show progress
-    log(f"Source {index + 1} of {len(sources)} - {source.get('id', 'No ID')}", 2)
+    log(f"Source {index + 1} of {len(sources)} - {source.get('id', '[no ID]')}", 2)
 
     # new citation for source
     new_citation = {}

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -102,6 +102,7 @@ for index, source in enumerate(sources):
             # if manually-entered source, throw error on cite failure
             if source.get("_plugin") == "sources":
                 will_exit = True
+            continue
     else:
         # pass source through untouched
         log("Passing source through", 3)

--- a/auto-cite/auto-cite.py
+++ b/auto-cite/auto-cite.py
@@ -8,8 +8,8 @@ try:
     config = load_data("../_config.yaml", type_check=False).get("auto-cite")
     if not config:
         raise Exception("Couldn't find auto-cite key in config")
-except Exception as message:
-    log(message, 3, "red")
+except Exception as e:
+    log(e, 3, "red")
     exit(1)
 
 log("Compiling list of sources to cite")
@@ -40,8 +40,8 @@ for plugin in config.get("plugins", []):
             data = load_data(file)
             # run plugin
             plugin_sources = import_module(f"plugins.{name}").main(data)
-        except Exception as message:
-            log(message, 3, "red")
+        except Exception as e:
+            log(e, 3, "red")
             will_exit = True
 
         log(f"Got {len(plugin_sources)} sources", 2, "green")
@@ -66,8 +66,8 @@ log("Generating citations for sources")
 citations = []
 try:
     citations = load_data(config["output"])
-except Exception as message:
-    log(message, 2, "yellow")
+except Exception as e:
+    log(e, 2, "yellow")
 
 # error exit flag
 will_exit = False
@@ -97,8 +97,8 @@ for index, source in enumerate(sources):
         try:
             new_citation = cite_with_manubot(source)
         # if Manubot couldn't cite source
-        except Exception as message:
-            log(message, 3, "red")
+        except Exception as e:
+            log(e, 3, "red")
             # if manually-entered source, throw error on cite failure
             if source.get("_plugin") == "sources":
                 will_exit = True
@@ -129,8 +129,8 @@ log("Exporting citations")
 # save new citations
 try:
     save_data(config["output"], new_citations)
-except Exception as message:
-    log(message, 2, "red")
+except Exception as e:
+    log(e, 2, "red")
     exit(1)
 
 log(f"Exported {len(new_citations)} citations", 2, "green")

--- a/auto-cite/plugins/orcid.py
+++ b/auto-cite/plugins/orcid.py
@@ -37,8 +37,8 @@ def main(data):
             request = Request(url=url, headers=headers)
             response = json.loads(urlopen(request).read())
         # if problem with orcid lookup
-        except Exception as message:
-            log(message, 3, "red")
+        except Exception as e:
+            log(e, 3, "red")
             will_exit = True
             continue
 

--- a/auto-cite/plugins/orcid.py
+++ b/auto-cite/plugins/orcid.py
@@ -64,7 +64,7 @@ def main(data):
 
     # exit at end of loop if error occurred
     if will_exit:
-        log("One or more ORCIDs failed to be cited", 3, "red")
+        log("One or more ORCIDs failed", 3, "red")
         exit(1)
 
     # return flat list of sources

--- a/auto-cite/plugins/orcid.py
+++ b/auto-cite/plugins/orcid.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.request import Request, urlopen
 import json
 from util import *
@@ -12,14 +13,34 @@ def main(data):
     # list of sources to return
     all_sources = []
 
+    # error exit flag
+    will_exit = False
+
     for index, entry in enumerate(data):
         # show progress
-        log(f"Orcid {index + 1} of {len(data)} - {entry.get('orcid', '-')}", 3, "cyan")
+        log(
+            f"ORCID {index + 1} of {len(data)} - {entry.get('orcid', '[no ORCID]')}",
+            3,
+            "cyan",
+        )
+
+        # get id
+        id = entry.get("orcid")
+        if not id:
+            log('No "orcid" key', 3, "red")
+            will_exit = True
+            continue
 
         # query api to get dois from orcid
-        url = endpoint.replace("$ORCID", entry.get("orcid", "-"))
-        request = Request(url=url, headers=headers)
-        response = json.loads(urlopen(request).read())
+        try:
+            url = endpoint.replace("$ORCID", id)
+            request = Request(url=url, headers=headers)
+            response = json.loads(urlopen(request).read())
+        # if problem with orcid lookup
+        except Exception as message:
+            log(message, 3, "red")
+            will_exit = True
+            continue
 
         # go through response structure and pull out ids e.g. doi:1234/56789
         works = response["group"]
@@ -33,13 +54,18 @@ def main(data):
                 source = {"id": f"{id_type}:{id_value}"}
 
                 # show progress
-                log(source.get("id", "-"), 3)
+                log(source.get("id", "[no ID]"), 3)
 
                 # copy fields from entry to source
                 source.update(entry)
 
                 # add source to collection
                 all_sources.append(source)
+
+    # exit at end of loop if error occurred
+    if will_exit:
+        log("One or more ORCIDs failed to be cited", 3, "red")
+        exit(1)
 
     # return flat list of sources
     return all_sources

--- a/auto-cite/plugins/sources.py
+++ b/auto-cite/plugins/sources.py
@@ -7,7 +7,7 @@ def main(data):
 
     for entry in data:
         # show progress
-        log(entry.get("id", "-"), 3, "white")
+        log(entry.get("id", "[no ID]"), 3, "white")
 
         # add each entry to collection
         all_sources.append(entry)

--- a/auto-cite/util.py
+++ b/auto-cite/util.py
@@ -87,8 +87,8 @@ def load_data(filename, type_check=True):
     # try to open file
     try:
         file = open(path, encoding="utf8")
-    except Exception as message:
-        raise Exception(message or f"Can't open {filename}")
+    except Exception as e:
+        raise Exception(e or f"Can't open {filename}")
 
     # try to parse as yaml
     try:
@@ -149,8 +149,8 @@ def cite_with_manubot(source):
     try:
         commands = ["manubot", "cite", id, "--log-level=WARNING"]
         output = subprocess.Popen(commands, stdout=subprocess.PIPE).communicate()
-    except Exception as error:
-        log(error, 3, "gray")
+    except Exception as e:
+        log(e, 3, "gray")
         raise Exception("Manubot could not generate citation")
 
     # parse results as json


### PR DESCRIPTION
Closes #121 

- temporarily track which plugin source came from with `_plugin` and `_input`, then ignore `exit()` when it is a metasource to address #121. delete these keys before exporting.
- better error catching for various error-prone points
- make logging and `.get()` fallbacks better
- make `exit()`s happen at end of loop with `will_exit` flags, instead of stopping in the middle so users can see all entries that cause problems at once
- rerun auto-cite and regenerate cache keys due to renaming of internal `_plugin` and `_input` keys
- change "message" in exception catching to "e" to match convention
- update docs to reflect above

Tested with Milton Pividori's ORCID: `0000-0002-3035-4403` which produces a few `eid:` sources that Manubot can't cite.