### PR TITLE
update auto-cite workflow

### DIFF
--- a/.github/workflows/auto-cite.yaml
+++ b/.github/workflows/auto-cite.yaml
@@ -19,6 +19,7 @@ jobs:
   update_research:
     name: Auto Cite
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -30,6 +31,7 @@ jobs:
         run: python -m pip install --upgrade --requirement ./auto-cite/requirements.txt
       - name: Build updated citations
         run: python ./auto-cite/auto-cite.py
+        timeout-minutes: 15
       - name: Commit updated citations
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/auto-cite.yaml
+++ b/.github/workflows/auto-cite.yaml
@@ -6,9 +6,14 @@ on:
       - main
     paths:
       - "_data/sources.yaml"
+      - "_data/orcid.yaml"
   pull_request:
     paths:
       - "_data/sources.yaml"
+      - "_data/orcid.yaml"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1"
 
 jobs:
   update_research:

--- a/.github/workflows/auto-cite.yaml
+++ b/.github/workflows/auto-cite.yaml
@@ -11,9 +11,9 @@ on:
     paths:
       - "_data/sources.yaml"
       - "_data/orcid.yaml"
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: "0 0 * * 1"
 
 jobs:
   update_research:

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -50,14 +50,14 @@
 
     {%- assign authors = citation.authors | default: emptyarray -%}
     <div
-      class="citation_authors {% if rich %}truncate{% endif %}"
-      {% if rich %}tabindex="0"{% endif %}
+      class="citation_authors truncate"
+      tabindex="0"
     >
       {{ authors | join: ", " }}
     </div>
 
-    {%- assign publisher = citation.publisher | default: "" -%}
-    {%- assign date = citation.date | default: "1900-01-01" -%}
+    {%- assign publisher = citation.publisher | default: "[no publisher info]" -%}
+    {%- assign date = citation.date | default: "[no date info]" -%}
     <div class="citation_details">
       {{ publisher }}&nbsp; · &nbsp;{{ date | date: "%d %b %Y" }}
     </div>

--- a/auto-cite/util.py
+++ b/auto-cite/util.py
@@ -15,9 +15,6 @@ yaml.Dumper.ignore_aliases = lambda *args: True
 # current working directory
 directory = os.path.dirname(os.path.realpath(__file__))
 
-# fallback year, month, day
-default_date = [1900, 1, 1]
-
 # allow printing ANSI color codes on Windows
 os.system("")
 
@@ -64,7 +61,7 @@ def date_part(citation, index):
     try:
         return citation.get("issued").get("date-parts")[0][index]
     except Exception:
-        return default_date[index]
+        return ""
 
 
 # format date string with leading 0's
@@ -72,7 +69,7 @@ def clean_date(date):
     try:
         return datetime.strptime(date, "%Y-%m-%d").strftime("%Y-%m-%d")
     except Exception:
-        return "-".join(str(part) for part in default_date)
+        return ""
 
 
 # read data from yaml file
@@ -179,13 +176,17 @@ def cite_with_manubot(source):
     container = manubot.get("container-title", "")
     collection = manubot.get("collection-title", "")
     publisher = manubot.get("publisher", "")
-    citation["publisher"] = container or publisher or collection
+    citation["publisher"] = container or publisher or collection or ""
 
     # date
     year = date_part(manubot, 0)
-    month = date_part(manubot, 1)
-    day = date_part(manubot, 2)
-    citation["date"] = f"{year}-{month}-{day}"
+    if year:
+        month = date_part(manubot, 1) or "1"
+        day = date_part(manubot, 2) or "1"
+        citation["date"] = clean_date(f"{year}-{month}-{day}")
+    else:
+        citation["date"] = ""
+
 
     # link
     citation["link"] = manubot.get("URL", "")


### PR DESCRIPTION
closes #124 

- add the ability to run auto-cite workflow periodically, or on demand (through the github website interface), but comment out
- increase timeout for auto-cite workflow
- better citation date handling and fallbacks
- truncate non-rich citation authors

---

~Testing in https://github.com/greenelab/greenelab.com/pull/64 before merging.~

https://github.com/greenelab/greenelab.com/actions/runs/3079195293/jobs/4975238923 scheduled workflow ran successfully ✅ 