### PR TITLE
Tweaks

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -16,10 +16,10 @@ RUN VERSION=$(grep -A 1 'BUNDLED WITH' Gemfile.lock | tail -n 1 | xargs); \
 RUN apt update && apt install -y python3 python3-pip
 
 # install python packages
-RUN python3 -m pip install --upgrade --requirement requirements.txt
+RUN python3 -m pip install --no-cache-dir --upgrade --requirement requirements.txt
 
 # install python package for listening for file changes
-RUN pip install "watchdog[watchmedo]"
+RUN pip install "watchdog[watchmedo]==3.0.0"
 
 # ports used by jekyll
 EXPOSE 4000

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -6,8 +6,11 @@ echo ""
 ls
 echo ""
 
-# run jekyll serve in hot-reload mode.
-# rerun whenever _config.yaml changes (jekyll hot-reload doesn't work with this file).
+# run cite process
+python3 _cite/cite.py
+
+# run jekyll serve in hot-reload mode
+# rerun whenever _config.yaml changes (jekyll hot-reload doesn't work with this file)
 watchmedo auto-restart \
     --debug-force-polling \
     --patterns="_config.yaml" \
@@ -15,10 +18,10 @@ watchmedo auto-restart \
     -- bundle exec jekyll serve --open-url --force_polling --livereload --trace --host=0.0.0.0 \
     | sed 's/0.0.0.0/localhost/g' &
 
-# run cite process.
-# rerun whenever _data files change.
+# rerun cite process whenever _data files change
 watchmedo shell-command \
     --debug-force-polling \
     --recursive \
+    --wait \
     --command="python3 _cite/cite.py" \
     --patterns="_data/sources*;_data/orcid*;_data/pubmed*;_data/google-scholar*" \

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -49,7 +49,6 @@ jobs:
       - name: Remove unneeded files
         run: |
           rm -rf \
-            README.md \
             CHANGELOG.md \
             testbed.md \
             .github/ISSUE_TEMPLATE \

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -29,7 +29,7 @@ jobs:
           ref: gh-pages
 
       - name: Clear Pages branch
-        run: rm -rf * .github .gitignore
+        run: rm -rf * .github .gitignore .docker
 
       - name: Make .nojekyll file
         run: touch .nojekyll
@@ -72,25 +72,22 @@ jobs:
           _Built with [Lab Website Template](https://greene-lab.gitbook.io/lab-website-template-docs)_
           " > README.md
 
-      - name: Install packages
-        run: yarn add yaml
-
       - name: Personalize Jekyll config for user
         uses: actions/github-script@v6
         with:
           script: |
             const { readFileSync, writeFileSync } = require("fs");
-            const { parse, stringify } = require("yaml");
             const file = "_config.yaml";
-            const config = parse(readFileSync(file).toString());
-            config.title = "${{ env.USER }}";
-            config.description = "${{ env.DESCRIPTION }}";
-            config.email = "contact@${{ env.USER }}.com";
-            config.github = "${{ env.USER }}";
-            config.twitter = "${{ env.USER }}";
-            config.instagram = "${{ env.USER }}";
-            config.youtube = "${{ env.USER }}";
-            writeFileSync(file, stringify(config));
+            const contents = readFileSync(file)
+              .toString()
+              .replace(/(^title: ).*$/m, "$1${{ env.USER }}")
+              .replace(/(^subtitle: ).*$/m, "$1")
+              .replace(/(^description: ).*$/m, "$1${{ env.DESCRIPTION }}")
+              .replace(/(^  email: ).*$/m, "$1contact@${{ env.USER }}.com")
+              .replace(/(^  github: ).*$/m, "$1${{ env.USER }}")
+              .replace(/(^  twitter: ).*$/m, "$1${{ env.USER }}")
+              .replace(/(^  youtube: ).*$/m, "$1${{ env.USER }}");
+            writeFileSync(file, contents);
 
       - name: Personalize homepage for user
         uses: actions/github-script@v6

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -29,7 +29,7 @@ jobs:
           ref: gh-pages
 
       - name: Clear Pages branch
-        run: rm -rf * .github .gitignore .docker
+        run: rm -rf * .*
 
       - name: Make .nojekyll file
         run: touch .nojekyll

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -8,7 +8,9 @@
 <div class="citation">
   {% if include.style == "rich" %}
     <a
-      href="{{ citation.link | relative_url }}"
+      {% if citation.link %}
+        href="{{ citation.link | relative_url }}"
+      {% endif %}
       class="citation-image"
       aria-label="{{ citation.title | default: "citation link" }}"
     >
@@ -25,8 +27,13 @@
     {% assign type = site.data.types[citation.type] %}
     {% include icon.html icon=type.icon %}
 
-    <a href="{{ citation.link }}" class="citation-title">
-      {{ citation.title }}
+    <a
+      {% if citation.link %}
+        href="{{ citation.link | relative_url }}"
+      {% endif %}
+      class="citation-title"
+    >
+      {{ citation.title | default: "[no title info]" }}
     </a>
 
     <div

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -19,7 +19,7 @@
 
   {% assign excerpt = post.content
     | default: ""
-    | regex_scan: "<!-- excerpt start -->(.*)<!-- excerpt end -->"
+    | regex_scan: "<!-- excerpt start -->(.*)<!-- excerpt end -->", true
     | default: post.excerpt
     | default: ""
     | strip_html

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -24,7 +24,12 @@
     | default: ""
     | strip_html
   %}
-  <p data-search="{{ post.content | strip_html | strip_newlines }}">
+  {% assign search = post.content
+    | strip_html 
+    | strip_newlines
+    | regex_strip
+  %}
+  <p data-search="{{ search }}">
     {{ excerpt }}
   </p>
 </div>

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% capture col1 %}
+{% capture floatcontent %}
 
 {% include portrait.html lookup=page.slug %}
 
@@ -10,13 +10,13 @@ layout: default
   {% for link in page.links %}
     {% assign key = link[0] %}
     {% assign value = link[1] %}
-    {% include button.html type=key link=value style="bare" %}
+    {% include button.html type=key link=value style="bare" %}<br>
   {% endfor %}
 </div>
 
 {% endcapture %}
 
-{% capture col2 %}
+{% include float.html content=floatcontent %}
 
 {{ content }}
 
@@ -33,7 +33,7 @@ layout: default
 {%- endcapture %}
 
 <a href="{{ search | relative_url }}">
-  See {{ page.name | default: page.title }}'s papers on the Research page
+  Search for {{ page.name | default: page.title }}'s papers on the Research page
 </a>
 
 {% capture search -%}
@@ -45,7 +45,3 @@ layout: default
   See {{ page.name | default: page.title }}'s posts on the Blog page
 </a>
  -->
- 
-{% endcapture %}
-
-{% include cols.html col1=col1 col2=col2 %}

--- a/_plugins/misc.rb
+++ b/_plugins/misc.rb
@@ -23,8 +23,8 @@ module Jekyll
     end
 
     def google_fonts(css)
-      names = regex_scan(css, '--\S*:\s*"(.*)",?.*;', true).sort.uniq
-      weights = regex_scan(css, '--\S*:\s(\d{3});', true).sort.uniq
+      names = regex_scan(css, '--\S*:\s*"(.*)",?.*;', false, true).sort.uniq
+      weights = regex_scan(css, '--\S*:\s(\d{3});', false, true).sort.uniq
       string = "https://fonts.googleapis.com/css2?display=swap&"
       for name in names do
         name.sub!" ", "+"

--- a/_plugins/regex.rb
+++ b/_plugins/regex.rb
@@ -2,8 +2,9 @@ require 'liquid'
 
 module Jekyll
   module RegexFilters
-    def regex_scan(string, search, all = false)
-      matches = string.scan(/#{search}/).flatten
+    def regex_scan(string, search, multi = false, all = false)
+      regex = multi ? /#{search}/m : /#{search}/
+      matches = string.scan(regex).flatten
       if matches.length
         return all ? matches : matches[0]
       else

--- a/_plugins/regex.rb
+++ b/_plugins/regex.rb
@@ -14,6 +14,10 @@ module Jekyll
     def regex_replace(string, search, replace)
       return string.gsub(/#{search}/m, replace)
     end
+
+    def regex_strip(string)
+      return string.gsub(/[^\p{L}\p{N}]/u, " ")
+    end
   end
 end
 

--- a/_styles/code.scss
+++ b/_styles/code.scss
@@ -20,8 +20,6 @@ code.highlighter-rouge {
 div.highlighter-rouge {
   width: 100%;
   margin: 40px 0;
-  background: #202020;
-  color: white;
   border-radius: var(--rounded);
   overflow-x: auto;
   overflow-y: auto;
@@ -33,6 +31,7 @@ div.highlighter-rouge {
 
     pre.highlight {
       width: fit-content;
+      min-width: 100%;
       margin: 0;
       padding: 20px;
       color: var(--white);

--- a/_styles/portrait.scss
+++ b/_styles/portrait.scss
@@ -30,6 +30,7 @@
 }
 
 .portrait-image {
+  width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: 999px;
   object-fit: cover;

--- a/_styles/post-excerpt.scss
+++ b/_styles/post-excerpt.scss
@@ -17,11 +17,15 @@
   margin: 0 !important;
 }
 
-.post-excerpt > *:first-child {
-  font-weight: var(--semi-bold);
+.post-excerpt > a:first-child {
   width: 100%;
+  font-weight: var(--semi-bold);
 }
 
 .post-excerpt > div {
   justify-content: flex-start;
+}
+
+.post-excerpt > p {
+  width: 100%;
 }

--- a/testbed.md
+++ b/testbed.md
@@ -315,11 +315,11 @@ With Markdown images
 
 ![image](https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp)
 
-![image](/images/icon.png)
+![image]({{ "/images/icon.png" | relative_url }})
 
-![image](/images/icon.png)
+![image]({{ "/images/icon.png" | relative_url }})
 
-![image](/images/icon.png)
+![image]({{ "/images/icon.png" | relative_url }})
 {% endcapture %}
 {% include grid.html content=content %}
 


### PR DESCRIPTION
- docker python install changes. pin watchdog version, turn off unneeded caching.
- docker entrypoint changes. run cite process immediately, ensure no simultaneous runs.
- first time setup fixes. don't parse config.yaml as yaml, instead customize with string replacement to preserve key order and comments.
- add title and link fallbacks to citation component
- fix start/end markers for blog post excerpts, and remove special characters from hidden search attribute
- change member page from col layout to float
- add multi-line option to regex_scan liquid plugin (to support start/end marker bug above)
- code, portrait, post excerpt css
- fix testbed image links