### PR TITLE
v1.1.2

### DIFF
--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -31,7 +31,7 @@ jobs:
 
       # clean slate, as if starting from orphan branch
       - name: Clear Pages branch
-        run: rm -rf * .*
+        run: rm -rf * .github .docker .gitignore
 
       # prevent GitHub from running Jekyll a second time after build
       - name: Make .nojekyll file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Reference: common-changelog.org
 
+## 1.1.2 - 2023-04-11
+
+### Changed
+
+- Fix first-time-setup rm bug.
+
 ## 1.1.1 - 2023-04-06
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 # citation metadata for the template itself
 
 title: "Lab Website Template"
-version: 1.1.1
-date-released: 2023-04-06
+version: 1.1.2
+date-released: 2023-04-11
 url: "https://github.com/greenelab/lab-website-template"
 authors:
   - family-names: "Rubinetti"


### PR DESCRIPTION
See https://github.com/greenelab/lab-website-template/discussions/177 . v1.1.1 introduced a regression in `first-time-setup.yaml` when clearing the `gh-pages` branch. I wanted to make the command simpler -- to simply delete everything in the folder -- but I didn't think it through enough. [There is a safeguard to prevent the command from working](https://unix.stackexchange.com/questions/369530/rm-refusing-to-remove-or-directory-skipping), and also even if it did work it would delete the `.git` folder which would break things. Thus, this version reverts the command to how it was before, manually specifying each `.` folder.