### PR TITLE
v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Reference: common-changelog.org
 
+## 1.3.4 - 2025-02-03
+
+### Changed
+
+- Fix section component parsing bug.
+
 ## 1.3.3 - 2025-01-25
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 # citation metadata for the template itself
 
 title: "Lab Website Template"
-version: 1.3.3
-date-released: 2025-01-25
+version: 1.3.4
+date-released: 2025-02-03
 url: "https://github.com/greenelab/lab-website-template"
 authors:
   - family-names: "Rubinetti"

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -10,12 +10,18 @@
 {% assign sections = content | split: "<!-- section break -->" | array_filter %}
 
 {% for section in sections %}
-  {% assign dark = section | regex_scan: "dark: (.*);" | default: "" %}
+  {% assign dark = section
+    | regex_scan: "<dark>(.*?)</dark>"
+    | default: ""
+  %}
   {% assign image = section
-    | regex_scan: "background: (.*);"
+    | regex_scan: "<background>(.*?)</background>"
     | default: nil
   %}
-  {% assign size = section | regex_scan: "size: (.*);" | default: "page" %}
+  {% assign size = section
+    | regex_scan: "<size>(.*?)</size>"
+    | default: "page"
+  %}
 
   <section
     class="background"

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -10,10 +10,10 @@
 {% assign title = title | xml_escape %}
 
 {% assign fulltitle = "" | split: "," %}
-{% if title %}
+{% if title and title != "" %}
   {% assign fulltitle = fulltitle | push: title %}
 {% endif %}
-{% if site.title %}
+{% if site.title and site.title != "" %}
   {% assign fulltitle = fulltitle | push: site.title %}
 {% endif %}
 {% assign fulltitle = fulltitle | join: " | " %}

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -48,6 +48,7 @@
         | strip_html
       %}
       {% assign search = post.content
+        | strip_html
         | strip_newlines
         | regex_strip
       %}

--- a/_includes/section.html
+++ b/_includes/section.html
@@ -4,7 +4,7 @@
 
 <!-- section break -->
 <!--
-  background: {{ include.background }};
-  dark: {{ include.dark }};
-  size: {{ include.size }};
+  <background>{{ include.background }}</background>
+  <dark>{{ include.dark }}</dark>
+  <size>{{ include.size }}</size>
 -->


### PR DESCRIPTION
Closes #305

This explanation is a bit hand-wavy, because I still can't follow the logic exactly. I find it hard to debug the flow of things in Jekyll because, while there's a `--trace` flag, the trace seems to be just the under-the-hood Ruby code, and not e.g. "you used this `_include` in this markdown file on this line, which then used this other `_include`, which then ran this Ruby filter, etc.".

But in general: 

Certain nested content (I think within the `post-excerpt` hidden `data-search` attribute) ended up making its way to `relative_url` in `content.html` (which should just be a url), but only in certain rare cases where the peculiarity of the regex matching in the `section` component didn't prevent it.

- change regex matching of `section` params in `content.html` to non-greedy, as they should've always been
- change string pattern of passing `section` params to `content.html` from `param: value;` to `<param>value</param>`. this should reduce the chances of incorrect parsing, because one of the params is a URL, which can have `;` characters in them, which would confuse the old format.
- fix unrelated bug where home page tab title looks like `| Lab Website Template` when it should just be `Lab Website Template` because the page title is `""`
- strip all html from `post-excerpt` `data-search` attribute, as it always should've been. is part of the main bug fix of this PR, but also will reduce false-positive search matches, because without it, `data-search` contains e.g. single `p` characters leftover from `<p>` tags. now `data-search` should truly only be the content of the post.

While not fully understanding the full flow of the root issue here, I think I've added enough safety mechanisms in enough spots to prevent similar issues from occurring in the future.

New template version checklist:

- [x] I have updated CITATION and CHANGELOG as appropriate.
- [x] I have updated lab-website-template-docs as appropriate.
- [x] I have checked the testbed as appropriate.
