### PR TITLE
v1.3.7

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Checkout branch contents

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Checkout branch contents
+        if: github.event.action != 'closed'
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -53,7 +54,30 @@ jobs:
           JEKYLL_ENV=production bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path || '' }}/${{ env.PREVIEWS_FOLDER }}/pr-${{ github.event.number }}"
 
       - name: Commit preview to Pages branch
+        if: github.event.action != 'closed'
         uses: rossjrw/pr-preview-action@v1.4.7
         with:
           source-dir: _site
           umbrella-dir: ${{ env.PREVIEWS_FOLDER }}
+
+      - name: Checkout Pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Clean up Pages branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { rm } = require("fs").promises;
+            const { PREVIEWS_FOLDER } = process.env;
+            const { owner, repo } = context.repo;
+            const prs = (await github.rest.pulls.list({ owner, repo, state: "closed" })).data;
+            for (const { number } of prs)
+              await rm(`${PREVIEWS_FOLDER}/pr-${number}`, { recursive: true, force: true });
+
+      - name: Commit changed files
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: gh-pages
+          commit_message: "Clean up previews"

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - name: Clean up Pages branch
+      - name: Clean up preview folders
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Checkout branch contents

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Create Pages branch

--- a/.github/workflows/update-citations.yaml
+++ b/.github/workflows/update-citations.yaml
@@ -29,6 +29,7 @@ jobs:
 
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Checkout branch contents

--- a/.github/workflows/update-url.yaml
+++ b/.github/workflows/update-url.yaml
@@ -20,6 +20,7 @@ jobs:
 
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Get Pages url

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - if: runner.debug == '1'
@@ -94,6 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug dump
+        if: runner.debug == '1'
         uses: crazy-max/ghaction-dump-context@v2
 
       - name: Checkout branch contents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reference: common-changelog.org
 ### Changed
 
 - Improve cleanup of PR preview folders in gh-pages branch.
+- Only run debug dump in debug mode to speed up workflow runs.
 
 ## 1.3.6 - 2025-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 Reference: common-changelog.org
 
+## 1.3.7 - 2025-07-31
+
+### Changed
+
+- Improve cleanup of PR preview folders in gh-pages branch.
+
 ## 1.3.6 - 2025-07-30
 
-- Improve behavior and flexibility of ORCID cite plugin
+### Changed
+
+- Improve behavior and flexibility of ORCID cite plugin.
 
 ## 1.3.5 - 2025-05-12
 
-###
+### Changed
 
 - Fix workflow bug where PR previews on GitHub Actions have broken styles/links/etc.
-- Fix tags component relative link bug
-- Make Actions workflows a bit more robust
+- Fix tags component relative link bug.
+- Make Actions workflows a bit more robust.
 
 ## 1.3.4 - 2025-02-03
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 # citation metadata for the template itself
 
 title: "Lab Website Template"
-version: 1.3.6
-date-released: 2025-07-30
+version: 1.3.7
+date-released: 2025-07-31
 url: "https://github.com/greenelab/lab-website-template"
 authors:
   - family-names: "Rubinetti"


### PR DESCRIPTION
Re-closes #191, specifically [this comment](https://github.com/greenelab/lab-website-template/issues/191#issuecomment-3062346669). Tested on a personal fork.

When a user has the "automatically delete branch on merge" setting enabled, by the time the `build-preview.yaml` workflow runs on pull request close, the branch is already gone and `actions/checkout` fails.

There are a few ways to solve this:

1. In the `actions/checkout` step, check out the `main` branch if the event is a PR close (regardless of the "auto-delete" option), or check out the PR branch otherwise.
2. Always try to check out the PR branch, and if it errors (user has the "auto-delete" option on), then try to check out `main`.
3. Only run first half of workflow if PR event != close. Then, always (on any PR activity) run the second half which gets all closed PR numbers and deletes their associated preview folders.

1 or 2 would work going forward, but I opted for the 3rd option because it will retroactively fix user's repos that have been affected by this shortcoming so far, like Casey's:
<img height="200" alt="Screenshot 2025-07-29 at 5 50 36 PM" src="https://github.com/user-attachments/assets/51649a7b-3b42-4768-a0dd-6b3d568aa841" />

New template version checklist:

- [x] I have updated CITATION and CHANGELOG as appropriate.
- [x] I have updated lab-website-template-docs as appropriate.
- [x] I have checked the testbed as appropriate.
