### PR TITLE
Fix doi (and other) filtering

### DIFF
--- a/_cite/plugins/orcid.py
+++ b/_cite/plugins/orcid.py
@@ -84,57 +84,60 @@ def main(entry):
         id_type = get_safe(_id, "external-id-type", "")
         id_value = get_safe(_id, "external-id-value", "")
 
-        # create source
-        source = {}
+        # if there is an id
+        if id_type and id_value:
 
-        # if id citable by manubot
-        if id_type and id_value and id_type in manubot_citable:
-            # id to cite with manubot
-            source = {"id": f"{id_type}:{id_value}"}
+            # create source
+            source = {}
 
-        # if not citable by manubot, keep citation details from orcid
-        else:
-            # get summaries
-            summaries = get_safe(work, "work-summary", [])
+            # if id is citable by manubot
+            if id_type in manubot_citable:
+                # id to cite with manubot
+                source = {"id": f"{id_type}:{id_value}"}
 
-            # get first summary with defined sub-value
-            def first(get_func):
-                return next(
-                    (value for value in map(get_func, summaries) if value), None
+            # if not citable by manubot, keep citation details from orcid
+            else:
+                # get summaries
+                summaries = get_safe(work, "work-summary", [])
+
+                # get first summary with defined sub-value
+                def first(get_func):
+                    return next(
+                        (value for value in map(get_func, summaries) if value), None
+                    )
+
+                # get title
+                title = first(lambda s: get_safe(s, "title.title.value", ""))
+
+                # get publisher
+                publisher = first(lambda s: get_safe(s, "journal-title.value", ""))
+
+                # get date
+                date = (
+                    get_safe(work, "last-modified-date.value")
+                    or first(lambda s: get_safe(s, "last-modified-date.value"))
+                    or get_safe(work, "created-date.value")
+                    or first(lambda s: get_safe(s, "created-date.value"))
+                    or 0
                 )
 
-            # get title
-            title = first(lambda s: get_safe(s, "title.title.value", ""))
+                # get link
+                link = first(lambda s: get_safe(s, "url.value", ""))
 
-            # get publisher
-            publisher = first(lambda s: get_safe(s, "journal-title.value", ""))
+                # keep available details
+                if title:
+                    source["title"] = title
+                if publisher:
+                    source["publisher"] = publisher
+                if date:
+                    source["date"] = format_date(date)
+                if link:
+                    source["link"] = link
 
-            # get date
-            date = (
-                get_safe(work, "last-modified-date.value")
-                or first(lambda s: get_safe(s, "last-modified-date.value"))
-                or get_safe(work, "created-date.value")
-                or first(lambda s: get_safe(s, "created-date.value"))
-                or 0
-            )
+            # copy fields from entry to source
+            source.update(entry)
 
-            # get link
-            link = first(lambda s: get_safe(s, "url.value", ""))
-
-            # keep available details
-            if title:
-                source["title"] = title
-            if publisher:
-                source["publisher"] = publisher
-            if date:
-                source["date"] = format_date(date)
-            if link:
-                source["link"] = link
-
-        # copy fields from entry to source
-        source.update(entry)
-
-        # add source to list
-        sources.append(source)
+            # add source to list
+            sources.append(source)
 
     return sources

--- a/_cite/plugins/orcid.py
+++ b/_cite/plugins/orcid.py
@@ -84,60 +84,61 @@ def main(entry):
         id_type = get_safe(_id, "external-id-type", "")
         id_value = get_safe(_id, "external-id-value", "")
 
-        # if there is an id
-        if id_type and id_value:
+        # if no available ids, skip source completely
+        # if not id_type or not id_value:
+            # continue
 
-            # create source
-            source = {}
+        # create source
+        source = {}
 
-            # if id is citable by manubot
-            if id_type in manubot_citable:
-                # id to cite with manubot
-                source = {"id": f"{id_type}:{id_value}"}
+        # if id citable by manubot
+        if id_type and id_value and id_type in manubot_citable:
+            # id to cite with manubot
+            source = {"id": f"{id_type}:{id_value}"}
 
-            # if not citable by manubot, keep citation details from orcid
-            else:
-                # get summaries
-                summaries = get_safe(work, "work-summary", [])
+        # if not citable by manubot, keep citation details from orcid
+        else:
+            # get summaries
+            summaries = get_safe(work, "work-summary", [])
 
-                # get first summary with defined sub-value
-                def first(get_func):
-                    return next(
-                        (value for value in map(get_func, summaries) if value), None
-                    )
-
-                # get title
-                title = first(lambda s: get_safe(s, "title.title.value", ""))
-
-                # get publisher
-                publisher = first(lambda s: get_safe(s, "journal-title.value", ""))
-
-                # get date
-                date = (
-                    get_safe(work, "last-modified-date.value")
-                    or first(lambda s: get_safe(s, "last-modified-date.value"))
-                    or get_safe(work, "created-date.value")
-                    or first(lambda s: get_safe(s, "created-date.value"))
-                    or 0
+            # get first summary with defined sub-value
+            def first(get_func):
+                return next(
+                    (value for value in map(get_func, summaries) if value), None
                 )
 
-                # get link
-                link = first(lambda s: get_safe(s, "url.value", ""))
+            # get title
+            title = first(lambda s: get_safe(s, "title.title.value", ""))
 
-                # keep available details
-                if title:
-                    source["title"] = title
-                if publisher:
-                    source["publisher"] = publisher
-                if date:
-                    source["date"] = format_date(date)
-                if link:
-                    source["link"] = link
+            # get publisher
+            publisher = first(lambda s: get_safe(s, "journal-title.value", ""))
 
-            # copy fields from entry to source
-            source.update(entry)
+            # get date
+            date = (
+                get_safe(work, "last-modified-date.value")
+                or first(lambda s: get_safe(s, "last-modified-date.value"))
+                or get_safe(work, "created-date.value")
+                or first(lambda s: get_safe(s, "created-date.value"))
+                or 0
+            )
 
-            # add source to list
-            sources.append(source)
+            # get link
+            link = first(lambda s: get_safe(s, "url.value", ""))
+
+            # keep available details
+            if title:
+                source["title"] = title
+            if publisher:
+                source["publisher"] = publisher
+            if date:
+                source["date"] = format_date(date)
+            if link:
+                source["link"] = link
+
+        # copy fields from entry to source
+        source.update(entry)
+
+        # add source to list
+        sources.append(source)
 
     return sources


### PR DESCRIPTION
#330 introduces an id type filtering to restrict sources, for instance, to doi, as discussed in #327 

However, `get_safe` always returns an empty string, even if `_id` is `None` after filtering. Consequently, a filtered-out citation will be processed as not citable by manubot, given the current logic, and result in an entry in `citations.yaml`. This behavior seems wrong.

This PR proposes a quick fix by simply checking that `id_type` and `id_value` are not empty. Feel free to use it.

- [ ] I have updated CITATION and CHANGELOG as appropriate.
- [ ] I have updated lab-website-template-docs as appropriate.
- [ ] I have checked the testbed as appropriate.
